### PR TITLE
Fix to PageContent build issues

### DIFF
--- a/src/apollo/pageContent/PageContent.tsx
+++ b/src/apollo/pageContent/PageContent.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { LoadingSpinner } from "hds-react";
 
 import { usePageQuery } from "../../common/headlessService/page";
-import PageContentWithoutData, {
+import {
+  PageContent as PageContentWithoutData,
   PageContentProps as PageContentPropsWithoutData,
 } from "../../core/pageContent/PageContent";
 import styles from "./pageContent.module.scss";

--- a/src/common/components/htmlToReact/HtmlToReact.tsx
+++ b/src/common/components/htmlToReact/HtmlToReact.tsx
@@ -17,7 +17,7 @@ type Components = {
     | string;
 };
 
-type Props = {
+type HtmlToReactProps = {
   children: string;
   components?: Components;
 };
@@ -67,7 +67,10 @@ function replaceDomNodeWithReactComponent(
   return domNode;
 }
 
-export default function HtmlToReact({ children: dirty, components }: Props) {
+export default function HtmlToReact({
+  children: dirty,
+  components,
+}: HtmlToReactProps) {
   const clean = useMemo(
     () =>
       DOMPurify.sanitize(dirty, {

--- a/src/common/components/list/List.tsx
+++ b/src/common/components/list/List.tsx
@@ -8,7 +8,7 @@ function getKey(...elements: JSX.Element[]): string {
   return elements.reduce((acc, element) => `${acc}${element.key}`, "");
 }
 
-type Props = {
+type ListProps = {
   items: (JSX.Element | JSX.Element[] | null | false)[];
   variant?:
     | "spacing-4-xs"
@@ -32,7 +32,7 @@ type Props = {
     | "spacing-layout-2-xl";
 };
 
-export default function List({ items, variant = "spacing-m" }: Props) {
+export default function List({ items, variant = "spacing-m" }: ListProps) {
   return (
     <ul className={classNames(styles.list, styles[variant])}>
       {items.map((item) =>

--- a/src/common/components/text/Text.tsx
+++ b/src/common/components/text/Text.tsx
@@ -12,7 +12,7 @@ type TextVariant =
   | "body-l"
   | "body-xl";
 
-type Props = {
+type TextVariantProps = {
   as?: string | React.ComponentType<HTMLAttributes<HTMLElement>>;
   variant?: TextVariant;
   children: ReactNode;
@@ -35,7 +35,13 @@ function getElement(variant: TextVariant) {
   }
 }
 
-function Text({ as, variant = "body", children, className, ...rest }: Props) {
+function Text({
+  as,
+  variant = "body",
+  children,
+  className,
+  ...rest
+}: TextVariantProps) {
   return React.createElement(
     as || getElement(variant),
     {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,3 @@
-import PageContent, { PageContentProps } from "./pageContent/PageContent";
-
 export { default as ConfigProvider } from "./configProvider/ConfigProvider";
 export { default as defaultConfig } from "./configProvider/defaultConfig";
 
@@ -19,6 +17,8 @@ export {
 
 export { default as Page, PageProps } from "./page/Page";
 
+export { PageContent, PageContentProps } from "./pageContent/PageContent";
+
 export { getCollections } from "./pageContent/utils";
 
 export type { Breadcrumb } from "./pageContent/types";
@@ -33,5 +33,3 @@ export type { CollectionType, CollectionItemType } from "./collection/types";
 export { default as Carousel, CarouselProps } from "./carousel/Carousel";
 
 export { default as Card, CardProps } from "./card/Card";
-
-export { PageContent, PageContentProps };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,5 @@
+import PageContent, { PageContentProps } from "./pageContent/PageContent";
+
 export { default as ConfigProvider } from "./configProvider/ConfigProvider";
 export { default as defaultConfig } from "./configProvider/defaultConfig";
 
@@ -17,12 +19,7 @@ export {
 
 export { default as Page, PageProps } from "./page/Page";
 
-export {
-  default as PageContent,
-  PageContentProps,
-} from "./pageContent/PageContent";
-
-export { getCollections, getCollectionCards } from "./pageContent/utils";
+export { getCollections } from "./pageContent/utils";
 
 export type { Breadcrumb } from "./pageContent/types";
 
@@ -36,3 +33,5 @@ export type { CollectionType, CollectionItemType } from "./collection/types";
 export { default as Carousel, CarouselProps } from "./carousel/Carousel";
 
 export { default as Card, CardProps } from "./card/Card";
+
+export { PageContent, PageContentProps };

--- a/src/core/page/Page.stories.tsx
+++ b/src/core/page/Page.stories.tsx
@@ -8,7 +8,7 @@ import { LanguageCodeEnum } from "../../common/headlessService/types";
 import ConfigProvider from "../configProvider/ConfigProvider";
 import defaultConfig from "../configProvider/defaultConfig";
 import pageMock from "../pageContent/__mocks__/page.mock";
-import PageContent from "../pageContent/PageContent";
+import { PageContent } from "../pageContent/PageContent";
 import navigationLanguages from "../navigation/__mocks__/navigationLanguages.mock";
 import navigationMenu from "../navigation/__mocks__/navigationMenu.mock";
 import Navigation from "../navigation/Navigation";

--- a/src/core/pageContent/PageContent.stories.tsx
+++ b/src/core/pageContent/PageContent.stories.tsx
@@ -7,7 +7,7 @@ import ConfigProvider from "../configProvider/ConfigProvider";
 import defaultConfig from "../configProvider/defaultConfig";
 import pageMock from "./__mocks__/page.mock";
 import pageWithDiverseContent from "./__mocks__/pageWithDiverseContent.mock";
-import PageContent from "./PageContent";
+import { PageContent } from "./PageContent";
 import Collection from "../collection/Collection";
 import Card from "../card/Card";
 import { getCollectionCards, getCollections } from "./utils";

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -16,7 +16,7 @@ export type PageContentProps = {
   collections?: React.ReactElement<typeof Collection>[];
 };
 
-export default function PageContent({
+export function PageContent({
   page,
   breadcrumbs,
   collections,

--- a/src/core/pageContent/PageContentBreadcrumbs.tsx
+++ b/src/core/pageContent/PageContentBreadcrumbs.tsx
@@ -4,11 +4,13 @@ import useConfig from "../configProvider/useConfig";
 import { Breadcrumb } from "./types";
 import styles from "./pageContentBreadcrumbs.module.scss";
 
-type Props = {
+type PageContentBreadcrumbsProps = {
   breadcrumbs: Breadcrumb[];
 };
 
-export default function PageContentBreadcrumbs({ breadcrumbs }: Props) {
+export default function PageContentBreadcrumbs({
+  breadcrumbs,
+}: PageContentBreadcrumbsProps) {
   const {
     copy: { breadcrumbNavigationLabel, breadcrumbListLabel },
     components: { A },

--- a/src/core/pageContent/PageContentLayout.tsx
+++ b/src/core/pageContent/PageContentLayout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { MAIN_CONTENT_ID } from "../../common/constants";
 import styles from "./pageContentLayout.module.scss";
 
-type Props = {
+type PageContentLayoutProps = {
   breadcrumbs?: React.ReactNode;
   content: React.ReactNode;
   collections?: React.ReactNode;
@@ -15,7 +15,7 @@ export default function PageContentLayout({
   content,
   collections,
   sidebarContent,
-}: Props) {
+}: PageContentLayoutProps) {
   return (
     <div className={styles.contentLayout}>
       {breadcrumbs && <div className={styles.breadcrumbs}>{breadcrumbs}</div>}

--- a/src/core/pageContent/PageMainContent.tsx
+++ b/src/core/pageContent/PageMainContent.tsx
@@ -5,7 +5,7 @@ import Text from "../../common/components/text/Text";
 import useConfig from "../configProvider/useConfig";
 import styles from "./pageMainContent.module.scss";
 
-type Props = {
+type PageMainContentProps = {
   title: string;
   content: string;
   imageSrc?: string;
@@ -17,7 +17,7 @@ export default function PageMainContent({
   content,
   imageSrc,
   imageAlt = "",
-}: Props) {
+}: PageMainContentProps) {
   const {
     components: { Img, Link },
   } = useConfig();

--- a/src/core/pageContent/__tests__/Page.test.tsx
+++ b/src/core/pageContent/__tests__/Page.test.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import { render, screen } from "../../../common/utils/testingLibrary";
 import pageMock, { sidebarLinkList } from "../__mocks__/page.mock";
-import Page from "../PageContent";
+import { PageContent } from "../PageContent";
 
 test("renders page with expected content", () => {
-  render(<Page page={pageMock} />);
+  render(<PageContent page={pageMock} />);
 
   // Title of page is presented correctly
   expect(

--- a/src/core/pageContent/meta/PageMeta.tsx
+++ b/src/core/pageContent/meta/PageMeta.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import { PageType } from "../../../common/headlessService/types";
 
-export type Props = {
+export type PageMetaProps = {
   page?: PageType;
   headComponent: React.ComponentType<{ children: React.ReactNode }>;
 };
 
-export default function PageMeta({ page, headComponent: Head }: Props) {
+export default function PageMeta({ page, headComponent: Head }: PageMetaProps) {
   const seoForCurrentLanguage = page?.seo;
   const {
     title,

--- a/src/core/pageContent/sidebarContent/SidebarContent.tsx
+++ b/src/core/pageContent/sidebarContent/SidebarContent.tsx
@@ -10,11 +10,11 @@ import {
 import SidebarContentLinkList from "./SidebarContentLinkList";
 import SidebarPostListItem from "./SidebarPostListItem";
 
-type Props = {
+type SidebarContentProps = {
   content?: SidebarContentType;
 };
 
-export default function SidebarContent({ content }: Props) {
+export default function SidebarContent({ content }: SidebarContentProps) {
   return (
     <List
       variant="spacing-3-xl"

--- a/src/core/pageContent/sidebarContent/SidebarContentCard.tsx
+++ b/src/core/pageContent/sidebarContent/SidebarContentCard.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 import useConfig from "../../configProvider/useConfig";
 import styles from "./sidebarContentCard.module.scss";
 
-type Props = {
+type SidebarContentCardProps = {
   title: string;
   url: string;
   imageUrl?: string;
@@ -17,7 +17,7 @@ export default function SidebarContentCard({
   url,
   imageUrl,
   imageAlt,
-}: Props) {
+}: SidebarContentCardProps) {
   const {
     components: { A, Img },
   } = useConfig();

--- a/src/core/pageContent/sidebarContent/SidebarContentLinkList.tsx
+++ b/src/core/pageContent/sidebarContent/SidebarContentLinkList.tsx
@@ -13,14 +13,14 @@ type Link = {
   url?: string | null;
 };
 
-type Props = LayoutLinkList;
+type SidebarContentLinkListProps = LayoutLinkList;
 
 export default function SidebarContentLinkList({
   anchor,
   title,
   description,
   links,
-}: Props) {
+}: SidebarContentLinkListProps) {
   return (
     <div id={anchor || undefined}>
       <h2>{title}</h2>

--- a/src/core/pageContent/sidebarContent/SidebarPostListItem.tsx
+++ b/src/core/pageContent/sidebarContent/SidebarPostListItem.tsx
@@ -6,14 +6,16 @@ import {
 } from "../../../common/headlessService/types";
 import SidebarContentCard from "./SidebarContentCard";
 
-type Props = LayoutArticle["articles"][number] | LayoutPage["pages"][number];
+type PostListItemProps =
+  | LayoutArticle["articles"][number]
+  | LayoutPage["pages"][number];
 
 export default function PostListItem({
   id,
   title,
   link,
   featuredImage,
-}: Props) {
+}: PostListItemProps) {
   if (!title || !link) {
     return null;
   }


### PR DESCRIPTION
There were strange issues inside the build package. When the library was used by a client app, the PageContent was typed with the properties of the Text-component. These changes seems to have fixed the issue.

1. Renamed the exported Props. HCRC-13. Because of some build errors, the props are renamed to more be more unique and so more followable.

2. Export named functions only from PageContent. HCRC-13. Page content had some issues in a rollup build process. When the HCRC lib was used, the props from Text-component were used instead of the PageContentProps. Exporting the PageContent as a named function instead of default fixed the issue.