### PR TITLE
Convert the table and the image widths to 100%

### DIFF
--- a/src/common/components/htmlToReact/HtmlToReact.tsx
+++ b/src/common/components/htmlToReact/HtmlToReact.tsx
@@ -15,6 +15,10 @@ type Components = {
   a?:
     | React.ComponentType<React.AnchorHTMLAttributes<HTMLAnchorElement>>
     | string;
+  table?:
+    | React.ComponentType<React.TableHTMLAttributes<HTMLTableElement>>
+    | string;
+  img?: React.ComponentType<React.ImgHTMLAttributes<HTMLImageElement>> | string;
 };
 
 type HtmlToReactProps = {
@@ -33,35 +37,59 @@ function DefaultH2({ children }: { children: React.ReactNode }) {
 function replaceDomNodeWithReactComponent(
   domNode: DOMNode,
   options?: HTMLReactParserOptions,
-  { p: P = DefaultP, h2: H2 = DefaultH2, a: A = "a" }: Components = {}
+  {
+    p: P = DefaultP,
+    h2: H2 = DefaultH2,
+    a: A = "a",
+    table: Table = "table",
+    img: IMG = "img",
+  }: Components = {}
 ) {
   // html-react-parser advices to do an instanceof check
   // domNode instanceof Element
   // However, this will fail between contexts. As this code is meant to be used
   // as a dependency, different contexts are likely.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_e.g._frames_or_windows
-  if ("attribs" in domNode && domNode.name === "p") {
-    return (
-      <P {...attributesToProps(domNode.attribs)}>
-        {domToReact(domNode.children, options)}
-      </P>
-    );
-  }
 
-  if ("attribs" in domNode && domNode.name === "h2") {
-    return (
-      <H2 {...attributesToProps(domNode.attribs)}>
-        {domToReact(domNode.children)}
-      </H2>
-    );
-  }
+  if ("attribs" in domNode) {
+    switch (domNode.name) {
+      case "p":
+        return (
+          <P {...attributesToProps(domNode.attribs)}>
+            {domToReact(domNode.children, options)}
+          </P>
+        );
 
-  if ("attribs" in domNode && domNode.name === "a") {
-    return (
-      <A {...attributesToProps(domNode.attribs)}>
-        {domToReact(domNode.children)}
-      </A>
-    );
+      case "h2":
+        return (
+          <H2 {...attributesToProps(domNode.attribs)}>
+            {domToReact(domNode.children)}
+          </H2>
+        );
+
+      case "a":
+        return (
+          <A {...attributesToProps(domNode.attribs)}>
+            {domToReact(domNode.children)}
+          </A>
+        );
+
+      case "table":
+        return (
+          <Table
+            {...attributesToProps(domNode.attribs)}
+            style={{ width: "100%" }}
+          >
+            {domToReact(domNode.children)}
+          </Table>
+        );
+
+      case "img":
+        return <IMG {...attributesToProps(domNode.attribs)} width="100%" />;
+
+      default:
+        break;
+    }
   }
 
   return domNode;


### PR DESCRIPTION
HCRC-40. The HEadless CMS sets the widths (in pixels) as an inline style to the images. They need to be stripped out. Also the table looks cooler when it's always full width. The img-tag with it's own attributes also wrecked the global layout width (so e.g. the carousel was always rendered in "desktop mode")!

A screenshot from Kultus after the fixes:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/389204/170022854-7afeb34d-fd58-46fc-8e3b-b60bddb74c1e.png">
