### PR TITLE
Routing refactoring part 3

### DIFF
--- a/src/core/configProvider/defaultConfig.tsx
+++ b/src/core/configProvider/defaultConfig.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { ModuleItemTypeEnum } from '../../common/headlessService/constants';
 import { LanguageCodeEnum } from '../../common/headlessService/types';
 import getIsValidHttpUrl from '../../common/utils/getIsValidHttpUrl';
-import { Link, LinkProps } from '../link/Link';
+import { LinkProps } from '../link/Link';
 import { Config } from './configContext';
 
 export const defaultConfig: Config = {
@@ -33,7 +33,9 @@ export const defaultConfig: Config = {
       // eslint-disable-next-line jsx-a11y/anchor-has-content
       <a {...props} />
     ),
-    Link: (props: LinkProps) => <Link {...props} />,
+    Link: ({ children, ...props }: LinkProps) => (
+      <span {...props}>{children}</span>
+    ),
     Img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
       // eslint-disable-next-line jsx-a11y/alt-text
       <img {...props} />

--- a/src/core/link/Link.tsx
+++ b/src/core/link/Link.tsx
@@ -56,8 +56,6 @@ export function Link({
   return isExternal ? (
     <>{linkComponent}</>
   ) : (
-    <RoutedLink href={href} {...delegatedProps}>
-      {linkComponent}
-    </RoutedLink>
+    <RoutedLink href={href}>{linkComponent}</RoutedLink>
   );
 }

--- a/src/core/link/Link.tsx
+++ b/src/core/link/Link.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
@@ -30,12 +31,13 @@ export function Link({
 }: LinkProps) {
   const {
     utils: { getIsHrefExternal },
+    components: { Link: RoutedLink },
   } = useConfig();
 
   const isOpenInNewTab = target === '_blank';
   const isExternal = getIsHrefExternal(href);
 
-  return (
+  const linkComponent = (
     <LinkBase
       size={size}
       {...delegatedProps}
@@ -49,5 +51,13 @@ export function Link({
     >
       {children as string}
     </LinkBase>
+  );
+
+  return isExternal ? (
+    <>{linkComponent}</>
+  ) : (
+    <RoutedLink href={href} {...delegatedProps}>
+      {linkComponent}
+    </RoutedLink>
   );
 }

--- a/src/core/linkBox/LinkBox.tsx
+++ b/src/core/linkBox/LinkBox.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
 
-import LinkBase from '../link/LinkBase';
-import { useConfig } from '../configProvider/useConfig';
+import { Link } from '../link/Link';
 import styles from './LinkBox.module.scss';
 
 export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -15,34 +14,15 @@ export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
 // TODO: this component should be replaced with hds one, when all layouts and directions are supported
 // issue is created to hds: https://github.com/City-of-Helsinki/helsinki-design-system/issues/809
 
-export function LinkBox({
-  href,
-  target,
-  children,
-  ariaLabel,
-  ...delegatedProps
-}: LinkProps) {
-  const {
-    utils: { getIsHrefExternal },
-  } = useConfig();
-
-  const isOpenInNewTab = target === '_blank';
-
+export function LinkBox({ children, ...delegatedProps }: LinkProps) {
   return (
     <div className={styles.linkBoxWrapper}>
       {children}
-      <LinkBase
+      <Link
         {...delegatedProps}
-        href={href}
-        openInNewTab={isOpenInNewTab}
-        external={getIsHrefExternal(href)}
-        ariaLabel={ariaLabel}
         className={classNames(styles.linkBox)}
         showExternalIcon={false}
-        disableVisitedStyles
-      >
-        {' '}
-      </LinkBase>
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
Refactored Linkbox
Added support of the routing link wrapper for the internal links. Now for the next projects we can pass the next/link

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
