### PR TITLE
Tag fix outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha52d",
+  "version": "1.0.0-alpha52",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha51",
+  "version": "1.0.0-alpha52d",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/components/tag/Tag.tsx
+++ b/src/common/components/tag/Tag.tsx
@@ -37,6 +37,7 @@ export function Tag({
         styles[`variant-${variant}`],
         featured && styles.featured,
         selected && styles.selected,
+        !onClick && styles.noOutline,
         className,
       )}
     >

--- a/src/common/components/tag/tag.module.scss
+++ b/src/common/components/tag/tag.module.scss
@@ -37,4 +37,8 @@
     --tag-background: var(--color-fog-light);
     cursor: pointer;
   }
+
+  &.noOutline {
+    --tag-focus-outline-color: none;
+  }
 }


### PR DESCRIPTION
## Description
Tags cannot be selected when no onclick event, so on click should be no outline style.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
