### PR TITLE
Use event types when fetching events by ids from LinkedEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha65",
+  "version": "1.0.0-alpha69",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/headlessService/__generated__.ts
+++ b/src/common/headlessService/__generated__.ts
@@ -2170,15 +2170,16 @@ export type DateQueryInput = {
   year?: InputMaybe<Scalars['Int']>;
 };
 
+/** Default images of different post types. Returns url of image of queried post type. Values come from Sivuston Asetukset -&gt; Oletuskuvat. */
 export type DefaultImages = {
   __typename?: 'DefaultImages';
-  /** Attachment ID for article image */
+  /** Attachment URL for article image */
   article?: Maybe<Scalars['String']>;
-  /** Attachment ID for event image */
+  /** Attachment URL for event image */
   event?: Maybe<Scalars['String']>;
-  /** Attachment ID for hero image */
+  /** Attachment URL for hero image */
   hero?: Maybe<Scalars['String']>;
-  /** Attachment ID for page image */
+  /** Attachment URL for page image */
   page?: Maybe<Scalars['String']>;
 };
 
@@ -2532,7 +2533,12 @@ export type EventSearch = {
   module?: Maybe<Scalars['String']>;
   /** List of modules */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Show all -link */
+  /**
+   * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
+   *                 hakutulosten osoite -link and search params of the module, for example:
+   *                 https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
+   *
+   */
   showAllLink?: Maybe<Scalars['String']>;
   /** Module title */
   title?: Maybe<Scalars['String']>;
@@ -2553,7 +2559,12 @@ export type EventSearchCarousel = {
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Events order */
   orderNewestFirst?: Maybe<Scalars['Boolean']>;
-  /** Show all -link */
+  /**
+   * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
+   *                                     hakutulosten osoite -link and search params of the module, for example:
+   *                                     https://client-url.com/search/?sort=end_time&amp;super_event_type=umbrella,none&amp;language=fi&amp;start=2022-10-29
+   *
+   */
   showAllLink?: Maybe<Scalars['String']>;
   /** Module title */
   title?: Maybe<Scalars['String']>;
@@ -6559,6 +6570,7 @@ export type RootQuery = {
    * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
    */
   pageBy?: Maybe<Page>;
+  /** Returns ID of page that uses the given template */
   pageByTemplate?: Maybe<Page>;
   /** Connection between the RootQuery type and the page type */
   pages?: Maybe<RootQueryToPageConnection>;

--- a/src/core/collection/Collection.tsx
+++ b/src/core/collection/Collection.tsx
@@ -8,6 +8,7 @@ import { Carousel, CarouselProps } from '../carousel/Carousel';
 import { Card } from '../card/Card';
 import Grid, { GridProps } from '../../common/components/grid/Grid';
 import {
+  EventTypeId,
   useEventListQuery,
   useEventsByIdsQuery,
 } from '../../common/eventsService/__generated__';
@@ -275,6 +276,7 @@ export function EventSelectionCollection({
       ids: collection.events,
       pageSize,
       include: ['in_language', 'keywords', 'location', 'audience'],
+      eventType: [EventTypeId.General, EventTypeId.Course],
     },
   });
 


### PR DESCRIPTION
HH-266. The event selection carousel uses the eventsByIds query. However, the LinkedEvents requires an event_type -attribute even then when fetching the events by ids. Added the 2 event types to the query-variables.

Before:
<img width="922" alt="image" src="https://user-images.githubusercontent.com/389204/206411069-43265fcd-4924-407f-9254-bb987ea6b100.png">

After:
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/389204/206411148-15368c5a-a372-426b-bd98-e35064fc921e.png">
