### PR TITLE
Export more Language types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha77",
+  "version": "1.0.0-alpha78",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/apollo/index.ts
+++ b/src/apollo/index.ts
@@ -14,7 +14,4 @@ export * from '../common/headlessService/tags';
 export * from '../common/headlessService/landingPage';
 export * from '../common/headlessService/pageByTemplate';
 export * from '../common/headlessService/menu';
-export {
-  LanguagesDocument,
-  LanguageCodeEnum,
-} from '../common/headlessService/languages';
+export * from '../common/headlessService/languages';

--- a/src/common/headlessService/utils.ts
+++ b/src/common/headlessService/utils.ts
@@ -22,6 +22,7 @@ import {
   EventSelected,
   EventSelectedCarousel,
   EventModule,
+  Language,
 } from './types';
 import { EventType } from '../eventsService/types';
 
@@ -155,6 +156,12 @@ export function isEventSearchCollection(
   collection: CollectionType,
 ): collection is EventSearchCollectionType {
   return (<EventSearchCollectionType>collection).url !== undefined;
+}
+
+export function isLanguage(
+  language: Language | null | undefined,
+): language is Language {
+  return !!(<Language>language);
 }
 
 export function filterPagesAndArticles(items: CollectionItemType[]) {


### PR DESCRIPTION
Export more types from the common headlessService and add a typeguard for Language type.

Related to HH-252 (https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/126)