### PR TITLE
feat(card): arrow link label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha95",
+  "version": "1.0.0-alpha96",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/card/Card.stories.tsx
+++ b/src/core/card/Card.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/function-component-definition */
 
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { ConfigProvider } from '../configProvider/ConfigProvider';
@@ -13,6 +13,10 @@ export default {
   title: 'Example/Card',
   component: Card,
 } as ComponentMeta<typeof Card>;
+
+const linkArrowLabelStyles = {
+  '--link-arrow-label-color': 'red',
+} as CSSProperties;
 
 const Template: ComponentStory<typeof Card> = (args) => (
   <ConfigProvider
@@ -31,10 +35,8 @@ const Template: ComponentStory<typeof Card> = (args) => (
         withShadow
         customContent={
           <>
-            <Tag variant="card" featured>
-              Maksuton
-            </Tag>
-            <Tag variant="card">Nuoret</Tag>
+            <Tag featured>Free</Tag>
+            <Tag>Youth</Tag>
           </>
         }
         imageLabel="Article"
@@ -46,4 +48,8 @@ const Template: ComponentStory<typeof Card> = (args) => (
 );
 
 export const CardDefault = Template.bind({});
-CardDefault.args = { ...card };
+CardDefault.args = {
+  ...card,
+  linkArrowLabel: 'This gives a label for the link arrow',
+  style: linkArrowLabelStyles,
+};

--- a/src/core/card/Card.tsx
+++ b/src/core/card/Card.tsx
@@ -19,12 +19,14 @@ export type CardProps = {
   text?: string;
   customContent?: React.ReactNode | string;
   hasLink?: boolean;
+  linkArrowLabel?: string;
   url?: string;
   withBorder?: boolean;
   withShadow?: boolean;
   direction?: 'fixed-horisontal' | 'fixed-vertical' | 'responsive';
   clampText?: boolean;
   openLinkInNewTab?: boolean;
+  style?: React.CSSProperties;
 };
 
 export function Card({
@@ -38,12 +40,14 @@ export function Card({
   text,
   customContent,
   hasLink,
+  linkArrowLabel,
   url,
   withBorder,
   withShadow,
   direction = 'responsive',
   clampText,
   openLinkInNewTab,
+  style,
 }: CardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const handleToggleActive = () => setIsHovered((val) => !val);
@@ -66,6 +70,7 @@ export function Card({
           direction && styles[direction],
           isHovered && styles.isHovered,
         )}
+        style={style}
       >
         <BackgroundImage
           id={id}
@@ -101,7 +106,13 @@ export function Card({
                 openInNewTab={openLinkInNewTab}
                 iconLeft={<IconArrowRight aria-hidden="true" />}
                 showExternalIcon={false}
-              />
+              >
+                {linkArrowLabel && (
+                  <span className={styles.linkArrowLabel}>
+                    {linkArrowLabel}
+                  </span>
+                )}
+              </Link>
             </div>
           )}
         </div>

--- a/src/core/card/card.module.scss
+++ b/src/core/card/card.module.scss
@@ -6,6 +6,8 @@
   --height-image: 8rem;
   --height-image-desktop: 14.5rem;
   --width-image: 8rem;
+  --link-arrow-color: black;
+  --link-arrow-label-color: var(--link-arrow-color);
 
   &.isHovered {
     .title {
@@ -145,18 +147,27 @@
   }
 
   .buttonWrapper {
+    vertical-align: middle;
+    line-height: var(--lineheight-l);
     display: flex;
     padding: 0 var(--spacing-s);
     padding-bottom: var(--spacing-2-xs);
+    color: var(--link-arrow-color);
     @include respond_above(s) {
       padding-bottom: var(--spacing-s);
     }
     order: 5;
     a {
       display: flex;
+      text-decoration: none;
+      color: var(--link-arrow-color);
       svg {
         height: var(--spacing-2-xl);
         width: var(--spacing-2-xl);
+      }
+      .linkArrowLabel {
+        color: var(--link-arrow-label-color);
+        padding-top: var(--spacing-xs);
       }
     }
   }


### PR DESCRIPTION
HH-283.
An arrow link inside a card can now have a label / text.
The label can be given as a parameter.
The text can be styled with card's style prop.

A screenshot from a storybook:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/389204/214604487-b672108a-2392-4a1c-92db-16ea16d34484.png">
