### PR TITLE
carousel mobile styles fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha96",
+  "version": "1.0.0-alpha97",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/carousel/carousel.module.scss
+++ b/src/core/carousel/carousel.module.scss
@@ -59,6 +59,10 @@
           margin-right: 28px;
         }
       }
+
+      svg {
+        color: var(--color-black-90);
+      }
     }
 
     .root {


### PR DESCRIPTION
## Description
Arrows net and previous should be black on iphone.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
