### PR TITLE
fix: convert booleans presented in string format to actual booleans

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha120",
+  "version": "1.0.0-alpha121",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/collection/Collection.tsx
+++ b/src/core/collection/Collection.tsx
@@ -23,13 +23,12 @@ import { useConfig } from '../configProvider/useConfig';
 import useEventsApolloClientFromConfig from '../configProvider/useEventsApolloClientFromConfig';
 import useVenuesApolloClientFromConfig from '../configProvider/useVenuesApolloClientFromConfig';
 import { Config } from '../configProvider/configContext';
-import normalizeKeys from '../../linkedEvents/utils/normalizeKeys';
 import { ModuleItemTypeEnum } from '../../common/headlessService/constants';
 import { Link } from '../link/Link';
 import { useVenuesByIdsQuery } from '../../common/venuesService/__generated__';
 import { VenueType } from '../../common/venuesService/types';
 import { LanguageCodeEnum } from '../../common/headlessService/types';
-import { getVenueIds, isEventClosed } from './utils';
+import { getVenueIds, isEventClosed, normalizeParamsValues } from './utils';
 import { DEFAULT_LOCALE } from '../../constants';
 import { isPageType, isArticleType } from '../../common/headlessService/utils';
 
@@ -224,18 +223,9 @@ export function EventSearchCollection({
     url.split('?')[1] ?? url.split('?')[0],
   );
   const params = Object.fromEntries(searchParams.entries());
-
-  const normalizedParams = { ...normalizeKeys(params) };
-
-  // fix for course event type lower case
-  if (normalizedParams.eventType) {
-    normalizedParams.eventType =
-      normalizedParams.eventType.charAt(0).toUpperCase() +
-      normalizedParams.eventType.slice(1);
-  }
-
+  const normalizedParams = normalizeParamsValues(params);
   const variables = {
-    ...normalizeKeys(params),
+    ...normalizedParams,
     pageSize,
     include: ['in_language', 'keywords', 'location', 'audience'],
   };

--- a/src/core/collection/utils.ts
+++ b/src/core/collection/utils.ts
@@ -1,6 +1,7 @@
 import isPast from 'date-fns/isPast';
 
 import { EventType } from '../../common/eventsService/types';
+import normalizeKeys from '../../linkedEvents/utils/normalizeKeys';
 
 export function getVenueIds(ids: number[]): string[] {
   return ids.map((id) => `tprek:${id}`);
@@ -8,3 +9,25 @@ export function getVenueIds(ids: number[]): string[] {
 
 export const isEventClosed = (event: EventType): boolean =>
   !!event?.endTime && isPast(new Date(event.endTime));
+
+export const normalizeParamsValues = (params: Record<string, string>) => {
+  const normalizedParams = { ...normalizeKeys(params) };
+
+  // Fix for course event type lower case
+  if (normalizedParams.eventType) {
+    normalizedParams.eventType =
+      normalizedParams.eventType.charAt(0).toUpperCase() +
+      normalizedParams.eventType.slice(1);
+  }
+
+  // Fix boolean types
+  Object.keys(normalizedParams).forEach((param) => {
+    if (normalizedParams[param] === 'true') {
+      normalizedParams[param] = true;
+    } else if (normalizedParams[param] === 'false') {
+      normalizedParams[param] = false;
+    }
+  });
+
+  return normalizedParams;
+};


### PR DESCRIPTION
HH-254.

It's clear that there has been a bug in the normalized params usage, 
because the eventType was already handled, but the mutated params-object
was actually never used.

The boolean strings "true / "false" are now handled in that same params-object.
Also the transforming function is moved to the file meant for utils related 
to the Collection-component.