### PR TITLE
Reject an empty image url and offer a fallback immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha123",
+  "version": "1.0.0-alpha124",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/utils/testImage.ts
+++ b/src/common/utils/testImage.ts
@@ -1,7 +1,11 @@
 /**
  * Test that loading image is successful
  */
-const testImage = (url: string): Promise<unknown> => {
+const testImage = (url?: string): Promise<unknown> => {
+  if (!url) {
+    return Promise.reject(new Error('No image URL given'));
+  }
+
   // Define the promise
   const imgPromise = new Promise<void>((resolve, reject) => {
     // Create the image

--- a/src/core/card/Card.tsx
+++ b/src/core/card/Card.tsx
@@ -12,7 +12,7 @@ export type CardProps = {
   id?: string;
   ariaLabel?: string;
   className?: string;
-  imageUrl?: string;
+  imageUrl?: string | null;
   imageLabel?: string;
   title?: string;
   subTitle?: string;

--- a/src/core/card/LargeCard.tsx
+++ b/src/core/card/LargeCard.tsx
@@ -12,7 +12,7 @@ export type LargeCardProps = {
   id?: string;
   ariaLabel?: string;
   imageLabel?: string;
-  imageUrl?: string;
+  imageUrl?: string | null;
   imagePosition?: 'right' | 'left';
   subTitle?: string;
   text?: string;

--- a/src/core/hooks/useResolveImageUrl.ts
+++ b/src/core/hooks/useResolveImageUrl.ts
@@ -6,7 +6,7 @@ import testImage from '../../common/utils/testImage';
 
 export type ResolveImageProps = {
   id?: string;
-  url?: string;
+  url?: string | null;
   customFallbackUrl?: string;
 };
 
@@ -26,12 +26,16 @@ export const useResolveImageUrl = ({
         setShowFallbackImage(true);
       }
     };
-    testThatImageExist();
+    if (url) {
+      testThatImageExist();
+    } else {
+      setShowFallbackImage(true);
+    }
   }, [url]);
 
   const randomIndex = Math.abs(hash(id ?? '')) % fallbackImageUrls.length;
 
-  return showFallbackImage
+  return !url || showFallbackImage
     ? customFallbackUrl ?? fallbackImageUrls[randomIndex]
     : url;
 };

--- a/src/core/image/BackgroundImage.tsx
+++ b/src/core/image/BackgroundImage.tsx
@@ -6,7 +6,7 @@ import { useResolveImageUrl } from '../hooks/useResolveImageUrl';
 
 export type BackgroundImageProps = {
   id: string;
-  url: string;
+  url?: string | null;
   customFallbackUrl?: string;
   labelTag?: string;
 } & React.HTMLAttributes<HTMLDivElement>;

--- a/src/core/pageContent/PageContentLayout.tsx
+++ b/src/core/pageContent/PageContentLayout.tsx
@@ -13,7 +13,7 @@ export type PageContentLayoutProps = {
   shareLinks?: React.ReactNode;
   collections?: React.ReactNode;
   sidebarContent: React.ReactNode;
-  imageSrc?: string;
+  imageSrc?: string | null;
   imageAlt?: string;
   imageLabel?: string;
   backUrl?: string;


### PR DESCRIPTION
LIIKUNTA-434

An undefined image url left the browser hanging and 
waiting for a request that could never succeed. 

Added a null value to image url type, because that
usually was the case where a fallback image was needed.

