### PR TITLE
fix: link icon styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha160",
+  "version": "1.0.0-alpha161",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha161",
+  "version": "1.0.0-alpha162",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/link/LinkBase.module.scss
+++ b/src/core/link/LinkBase.module.scss
@@ -24,12 +24,21 @@
 
 .linkS {
   composes: hds-link--small from './LinkBase.scss';
+  svg {
+    min-width: 16px;
+  }
 }
 
 .linkM {
   composes: hds-link--medium from './LinkBase.scss';
+  svg {
+    min-width: 24px;
+  }
 }
 
 .linkL {
   composes: hds-link--large from './LinkBase.scss';
+  svg {
+    min-width: 48px;
+  }
 }

--- a/src/core/link/LinkBase.module.scss
+++ b/src/core/link/LinkBase.module.scss
@@ -25,20 +25,20 @@
 .linkS {
   composes: hds-link--small from './LinkBase.scss';
   svg {
-    min-width: 16px;
+    min-width: var(--spacing-layout-2-xs);
   }
 }
 
 .linkM {
   composes: hds-link--medium from './LinkBase.scss';
   svg {
-    min-width: 24px;
+    min-width: var(--spacing-layout-xs);
   }
 }
 
 .linkL {
   composes: hds-link--large from './LinkBase.scss';
   svg {
-    min-width: 48px;
+    min-width: var(--spacing-layout-m);
   }
 }


### PR DESCRIPTION
## Description
Size of the external icon stays the same (not getting smaller if multiple lines of text)

<img width="280" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/16116141/fd9800fb-1ded-4104-bc88-e57e6d636fef">


## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
