### PR TITLE
fix: large card image ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha183",
+  "version": "1.0.0-alpha186",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha186",
+  "version": "1.0.0-alpha187",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/card/largeCard.module.scss
+++ b/src/core/card/largeCard.module.scss
@@ -58,7 +58,7 @@
     @include respond_above(s) {
       padding-bottom: 0;
       min-height: var(--height-image-desktop);
-      flex: 3 1;
+      flex: 1.5 1;
     }
 
     .imageLabel {


### PR DESCRIPTION
## Description
Image to text ration 1.5:1 in the large event card
https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-517

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
