### PR TITLE
chore: update types including events-helsinki-monorepo PR #413 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha187",
+  "version": "1.0.0-alpha188",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/eventsService/__generated__.ts
+++ b/src/common/eventsService/__generated__.ts
@@ -79,7 +79,7 @@ export type EventDetails = {
   eventStatus?: Maybe<Scalars['String']>;
   externalLinks: Array<ExternalLink>;
   id: Scalars['ID'];
-  images: Array<Image>;
+  images: Array<EventImage>;
   inLanguage: Array<InLanguage>;
   infoUrl?: Maybe<LocalizedObject>;
   internalContext?: Maybe<Scalars['String']>;
@@ -105,6 +105,23 @@ export type EventDetails = {
   typeId?: Maybe<EventTypeId>;
 };
 
+export type EventImage = {
+  __typename?: 'EventImage';
+  createdTime?: Maybe<Scalars['String']>;
+  cropping?: Maybe<Scalars['String']>;
+  dataSource?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  internalContext?: Maybe<Scalars['String']>;
+  internalId: Scalars['String'];
+  internalType?: Maybe<Scalars['String']>;
+  lastModifiedTime?: Maybe<Scalars['String']>;
+  license?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  photographerName?: Maybe<Scalars['String']>;
+  publisher?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
+
 export type EventListResponse = {
   __typename?: 'EventListResponse';
   data: Array<EventDetails>;
@@ -121,23 +138,6 @@ export type ExternalLink = {
   language?: Maybe<Scalars['String']>;
   link?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
-};
-
-export type Image = {
-  __typename?: 'Image';
-  createdTime?: Maybe<Scalars['String']>;
-  cropping?: Maybe<Scalars['String']>;
-  dataSource?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  internalContext?: Maybe<Scalars['String']>;
-  internalId: Scalars['String'];
-  internalType?: Maybe<Scalars['String']>;
-  lastModifiedTime?: Maybe<Scalars['String']>;
-  license?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  photographerName?: Maybe<Scalars['String']>;
-  publisher?: Maybe<Scalars['String']>;
-  url: Scalars['String'];
 };
 
 export type InLanguage = {
@@ -164,7 +164,7 @@ export type Keyword = {
   deprecated?: Maybe<Scalars['Boolean']>;
   hasUpcomingEvents?: Maybe<Scalars['Boolean']>;
   id?: Maybe<Scalars['ID']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   internalContext?: Maybe<Scalars['String']>;
   internalId: Scalars['String'];
   internalType?: Maybe<Scalars['String']>;
@@ -268,7 +268,7 @@ export type Place = {
   email?: Maybe<Scalars['String']>;
   hasUpcomingEvents?: Maybe<Scalars['Boolean']>;
   id?: Maybe<Scalars['ID']>;
-  image?: Maybe<Image>;
+  image?: Maybe<EventImage>;
   infoUrl?: Maybe<LocalizedObject>;
   internalContext?: Maybe<Scalars['String']>;
   internalId: Scalars['String'];
@@ -355,6 +355,7 @@ export type QueryEventListArgs = {
   page?: InputMaybe<Scalars['Int']>;
   pageSize?: InputMaybe<Scalars['Int']>;
   publisher?: InputMaybe<Scalars['ID']>;
+  publisherAncestor?: InputMaybe<Scalars['ID']>;
   sort?: InputMaybe<Scalars['String']>;
   start?: InputMaybe<Scalars['String']>;
   startsAfter?: InputMaybe<Scalars['String']>;
@@ -576,7 +577,7 @@ export type EventCmsEventFieldsFragment = {
     link?: string | null;
   }>;
   images: Array<{
-    __typename?: 'Image';
+    __typename?: 'EventImage';
     id?: string | null;
     name: string;
     url: string;
@@ -827,7 +828,7 @@ export type EventListQuery = {
         link?: string | null;
       }>;
       images: Array<{
-        __typename?: 'Image';
+        __typename?: 'EventImage';
         id?: string | null;
         name: string;
         url: string;
@@ -1026,7 +1027,7 @@ export type EventsByIdsQuery = {
         link?: string | null;
       }>;
       images: Array<{
-        __typename?: 'Image';
+        __typename?: 'EventImage';
         id?: string | null;
         name: string;
         url: string;

--- a/src/common/headlessService/__generated__.ts
+++ b/src/common/headlessService/__generated__.ts
@@ -3656,7 +3656,7 @@ export type LayoutCard = {
   /** Description */
   description?: Maybe<Scalars['String']>;
   /** Image */
-  image?: Maybe<Scalars['String']>;
+  image?: Maybe<Image>;
   /** Link */
   link?: Maybe<Link>;
   /** Title */
@@ -5591,6 +5591,8 @@ export type PostModulesUnionType =
   | LayoutImageGallery
   | LayoutPages
   | LayoutPagesCarousel
+  | LayoutSocialMediaFeed
+  | LayoutSteps
   | LocationsSelected
   | LocationsSelectedCarousel;
 
@@ -11271,6 +11273,8 @@ export type PostFragment = {
           } | null;
         } | null> | null;
       }
+    | { __typename?: 'LayoutSocialMediaFeed' }
+    | { __typename?: 'LayoutSteps' }
     | {
         __typename: 'LocationsSelected';
         title?: string | null;
@@ -11589,6 +11593,8 @@ export type ArticleQuery = {
             } | null;
           } | null> | null;
         }
+      | { __typename?: 'LayoutSocialMediaFeed' }
+      | { __typename?: 'LayoutSteps' }
       | {
           __typename: 'LocationsSelected';
           title?: string | null;
@@ -11938,6 +11944,8 @@ export type PostsQuery = {
                 } | null;
               } | null> | null;
             }
+          | { __typename?: 'LayoutSocialMediaFeed' }
+          | { __typename?: 'LayoutSteps' }
           | {
               __typename: 'LocationsSelected';
               title?: string | null;

--- a/src/mocks/queries/pageEventSelectionModule.ts
+++ b/src/mocks/queries/pageEventSelectionModule.ts
@@ -35,7 +35,7 @@ export const futureEvents = [
         name: '',
         url: 'https://www.harrastushaku.fi/images/activityimages/8898_dscn7427.jpg',
         photographerName: null,
-        __typename: 'Image',
+        __typename: 'EventImage',
       },
     ],
     subEvents: [],
@@ -224,7 +224,7 @@ export const ongoingEvents = [
         name: '',
         url: 'https://www.harrastushaku.fi/images/activityimages/8453_HARRASTUSHAKUUN.jpg',
         photographerName: null,
-        __typename: 'Image',
+        __typename: 'EventImage',
       },
     ],
     subEvents: [],
@@ -416,7 +416,7 @@ export const pastEventsWithoutEndingTime = [
         name: '',
         url: 'https://www.harrastushaku.fi/images/activityimages/9725_1.jpg',
         photographerName: null,
-        __typename: 'Image',
+        __typename: 'EventImage',
       },
     ],
     subEvents: [],
@@ -607,7 +607,7 @@ export const pastEvents = [
         name: '',
         url: 'https://www.harrastushaku.fi/images/activityimages/8444_Ruukuntekij.jpg',
         photographerName: null,
-        __typename: 'Image',
+        __typename: 'EventImage',
       },
     ],
     subEvents: [],
@@ -786,7 +786,7 @@ export const pastEvents = [
         name: 'äly ja väläys.jpg',
         url: 'https://api.hel.fi/linkedevents/media/images/%C3%A4ly_ja_v%C3%A4l%C3%A4ys.jpg',
         photographerName: '',
-        __typename: 'Image',
+        __typename: 'EventImage',
       },
     ],
     subEvents: [],
@@ -1036,7 +1036,7 @@ export const pastEvents = [
     Example query taken from the real response of Hobbies staging CMS: https://hobbies-graphql-proxy.test.hel.ninja/proxy/graphql.
     The response is modified so that there are 2 ongoing events and the rest of them are in the past.
 
-    query: 
+    query:
     ```
     query EventsByIds($ids: [ID!]!, $eventType: [EventTypeId], $include: [String], $sort: String, $pageSize: Int, $page: Int, $start: String, $end: String) {
         eventsByIds(


### PR DESCRIPTION
## Description

### chore: update types including events-helsinki-monorepo PR #413 changes

the changes in events-graphql-proxy were taken from a locally running
events-graphql-proxy, the version is from events-helsinki-monorepo
repository's PR #413:
 - https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/413

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
