### PR TITLE
fix: change lodash to lodash-es in order to fix the bundle issues

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   moduleNameMapper: {
     // return a mock css module
     '\\.(css|less|scss|sss|styl)$': 'identity-obj-proxy',
+     "^lodash-es$": "lodash"
   },
 
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/City-of-Helsinki/react-helsinki-headless-cms#readme",
   "peerDependencies": {
-    "@apollo/client": "^3.5.10",
+    "@apollo/client": "^3.7.16",
     "date-fns": "^2.28.0",
     "hds-react": ">=1.11.1",
     "react": ">=16.8.0",
@@ -50,7 +50,7 @@
     }
   },
   "devDependencies": {
-    "@apollo/client": "^3.8.1",
+    "@apollo/client": "^3.7.16",
     "@babel/core": "^7.22.10",
     "@babel/plugin-transform-runtime": "^7.22.10",
     "@babel/preset-env": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/dompurify": "^3.0.2",
     "@types/jest": "^29.5.3",
     "@types/jest-axe": "^3.5.5",
+    "@types/lodash-es": "^4.17.9",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
@@ -130,7 +131,7 @@
     "html-react-parser": "^4.2.1",
     "isomorphic-dompurify": "^1.8.0",
     "jest-environment-jsdom": "^29.6.2",
-    "lodash": "^4.17.21"
+    "lodash-es": "^4.17.21"
   },
   "msw": {
     "workerDirectory": "public"

--- a/src/core/collection/__tests__/Collection.test.tsx
+++ b/src/core/collection/__tests__/Collection.test.tsx
@@ -33,9 +33,9 @@ describe('event selection module', () => {
     });
 
     // All the ongoing events should be shown
-    activeEvents.forEach((event) => {
+    activeEvents.forEach(async (event) => {
       expect(
-        screen.getByRole('link', { name: event.name.fi }),
+        await screen.findByRole('link', { name: event.name.fi }),
       ).toBeInTheDocument();
     });
 
@@ -53,6 +53,9 @@ describe('event selection module', () => {
 
     // No other cards than the ongoing events should be shown.
     // There is a linkbox that wraps the whole card and another link that wraps the arrow-icon
-    expect(screen.getAllByRole('link').length).toBe(activeEvents.length * 2);
+    // so the amount could be double the events.
+    // However, the another link is with aria-hidden,
+    // so the amount of the links should be the amounts of events.
+    expect(screen.getAllByRole('link').length).toBe(activeEvents.length);
   });
 });

--- a/src/core/utils/string.ts
+++ b/src/core/utils/string.ts
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import camelCase from 'lodash/camelCase';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import startCase from 'lodash/startCase';
+import { camelCase, startCase } from 'lodash-es';
 
 export const getColor = (color: string): string =>
   startCase(camelCase(color)).replace(/\s/g, '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.8.1":
+"@apollo/client@^3.7.16":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.8.1.tgz#a1e3045a5fb276c08e38f7b5f930551d79741257"
   integrity sha512-JGGj/9bdoLEqzatRikDeN8etseY5qeFAY0vSAx/Pd0ePNsaflKzHx6V2NZ0NsGkInq+9IXXX3RLVDf0EotizMA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3914,7 +3914,14 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.167":
+"@types/lodash-es@^4.17.9":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.9.tgz#49dbe5112e23c54f2b387d860b7d03028ce170c2"
+  integrity sha512-ZTcmhiI3NNU7dEvWLZJkzG6ao49zOIjEgIE0RgV7wbPxU0f2xT3VSAHw2gmst8swH6V0YkLRGp4qPlX/6I90MQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.167":
   version "4.14.197"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.197.tgz#e95c5ddcc814ec3e84c891910a01e0c8a378c54b"
   integrity sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==
@@ -9228,6 +9235,11 @@ locate-path@^7.1.0:
   integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
   dependencies:
     p-locate "^6.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
HH-234

The HCRC-lib was build properly and the storybook could be used,
but when it was used as a plugin in an app,
the app whined about that there were commonjs `module.exports`
inside the bundled esm javascript.
The issues was in the lodash-library that was used as a dependency and
was added quit recently. The lodash is now replaced with lodash-es,
which should fit better in esm and nextjs world.

----

When the events-monorepo app was ran with the new version of the HCRC, it whined about `es modules may not assign module.exports or exports.*`. When I investigated what the bundled HCRC code had inside the line  that the debugger reported, there was a clear `module.export` declaration. The `module.export` is a way to export objects when using the `commonjs`. The ESM-module should use the `export default` or `export` instead. When I investigated what part of our code added the module.export code section in the bundle, I found out that the code comes from the `lodash`-library. Here is the lodash code that was included and the freeGlobal was exported in commonjs manner http://justinhelmer.github.io/lodash.github.io/docs/2.0.0/lodash.js.html. With `lodash-es` we could get rid of the errenous export-call. It should also be noted that the lodash-es is actually the preferred library when using the Webpack (v4 or later), because the Webpack can treeshake the content.

----
I published a canary: https://www.npmjs.com/package/react-helsinki-headless-cms/v/1.0.0-alpha197-canary-b0ab56a
```npm notice === Tarball Details === 
npm notice name:          react-helsinki-headless-cms                                  
npm notice version:       1.0.0-alpha197-canary-b0ab56a                                
npm notice filename:      react-helsinki-headless-cms-1.0.0-alpha197-canary-b0ab56a.tgz
```