### PR TITLE
fix: link base focus-visible outline to mirror focus styles

### DIFF
--- a/src/core/link/LinkBase.scss
+++ b/src/core/link/LinkBase.scss
@@ -19,7 +19,7 @@
 }
 
 .hds-link:focus-visible {
-  outline: none;
+  outline: 3px solid var(--color-coat-of-arms);
 }
 
 .hds-link .vertical-align-small-or-medium-icon {


### PR DESCRIPTION
LIIKUNTA-484. 

Set the same outline style to focus-visible as was set to focus for HDS link base.

<img width="887" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/24635208-5bd8-4ca7-babe-14dadade7674">

<img width="1041" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/58a1118e-4286-44c2-b819-759fd2f05c8c">

<img width="669" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/fec1888a-5b1d-4777-b3eb-4dadf3f2e3af">

<img width="303" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/64c0914d-ff71-457f-b991-907737b2b143">
