### PR TITLE
fix: card delimited url redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha214",
+  "version": "1.0.0-alpha215",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/card/Card.tsx
+++ b/src/core/card/Card.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import { IconArrowRight } from 'hds-react';
 import React, { useState } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -9,6 +11,7 @@ import { LinkBox } from '../linkBox/LinkBox';
 import { Link } from '../link/Link';
 import { BackgroundImage } from '../image/BackgroundImage';
 import { getColor, getTextFromHtml, isWhiteText } from '../utils/string';
+import { useConfig } from '../configProvider/useConfig';
 
 export type CardProps = {
   id?: string;
@@ -66,6 +69,25 @@ export function Card({
   const [isHovered, setIsHovered] = useState(false);
   const handleToggleActive = () => setIsHovered((val) => !val);
 
+  const {
+    utils: { redirectToUrl, getIsHrefExternal },
+  } = useConfig();
+
+  const openInNewTab = (): void => {
+    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
+  };
+
+  const handleClick = () => {
+    if (url) {
+      if (getIsHrefExternal(url)) {
+        openInNewTab();
+      } else {
+        redirectToUrl(url);
+      }
+    }
+  };
+
   const content = (
     <div
       className={classNames(
@@ -99,11 +121,13 @@ export function Card({
           isDelimited && styles.isDelimited,
         )}
       />
+
       <div
         className={classNames(
           styles.contentWrapper,
           isDelimited && styles.isDelimited,
         )}
+        onClick={handleClick}
       >
         <div
           className={classNames(


### PR DESCRIPTION
## Description
When card module has delimited param true, the click on the content does not work. PR fixes the issue

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
