### PR TITLE
fix(docker): update node version to v20, previous v16 was incompatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ===============================================
-FROM helsinkitest/node:16-slim as appbase
+FROM helsinkitest/node:20-slim as appbase
 # ===============================================
 
 # Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "publish-stable": "yarn build && node ./scripts/publish-stable.js",
     "generate:graphql": "cross-env DOTENV_CONFIG_PATH=./.env graphql-codegen -r dotenv/config --config codegen.yml"
   },
+  "engines": {
+    "node": ">=18.17.1"
+  },
   "exports": {
     ".": {
       "import": "./index.js",


### PR DESCRIPTION
## Description

### fix(docker): update node version to v20, previous v16 was incompatible

`docker compose up --build` failed with node v16 that was used in
Dockerfile because some package required at least node v18. Updated node
to v20 in Dockerfile and it seems to work.

### chore: set minimum node version to 18.17.1 in package.json

fixes package incompatibility:
```
error rollup-plugin-dts@6.0.0:
The engine "node" is incompatible with this module.
Expected version ">=v18.17.1". Got "16.20.2"
error Found incompatible module.
```

## Issues

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
