### PR TITLE
LIIKUNTA-466 | fix: fix table.css packaging, handle is-style-stripes style in figure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha216",
+  "version": "1.0.0-alpha217",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/components/htmlToReact/HtmlToReact.stories.tsx
+++ b/src/common/components/htmlToReact/HtmlToReact.stories.tsx
@@ -10,39 +10,44 @@ import { HtmlToReact, HtmlToReactProps, TABLE_VARIANTS } from './HtmlToReact';
 const videoMediaIframeContent =
   '\n<p>Demo page for iframes</p>\n\n\n\n<p>Youtube: </p>\n\n\n\n<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">\n<iframe loading="lazy" title="Bohemian Rhapsody | Muppet Music Video | The Muppets" width="500" height="281" src="https://www.youtube.com/embed/tgbNymZ7vqY?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>\n</div><figcaption class="wp-element-caption">Youtube caption</figcaption></figure>\n\n\n\n<p>Vimeo:</p>\n\n\n\n<figure class="wp-block-embed is-type-video is-provider-vimeo wp-block-embed-vimeo wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">\n<iframe loading="lazy" title="The New Vimeo Player (You Know, For Videos)" src="https://player.vimeo.com/video/76979871?h=8272103f6e&amp;dnt=1&amp;app_id=122963" width="500" height="281" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>\n</div><figcaption class="wp-element-caption">Vimeo caption</figcaption></figure>\n';
 
-const tableContent =
-  '<figure class="wp-block-table is-style-regular">' +
-  '  <table>' +
-  '    <thead>' +
-  '      <tr>' +
-  '        <th>Name</th>' +
-  '        <th>Species</th>' +
-  '        <th>Cover</th>' +
-  '        <th>Feet</th>' +
-  '      </tr>' +
-  '    </thead>' +
-  '    <tbody>' +
-  '      <tr>' +
-  '        <td>Ransu</td>' +
-  '        <td>Dog</td>' +
-  '        <td>Fur</td>' +
-  '        <td>4</td>' +
-  '      </tr>' +
-  '      <tr>' +
-  '        <td>Peto</td>' +
-  '        <td>Cat</td>' +
-  '        <td>Fur</td>' +
-  '        <td>4</td>' +
-  '      </tr>' +
-  '      <tr>' +
-  '        <td>Alex</td>' +
-  '        <td>Parrot</td>' +
-  '        <td>Feather</td>' +
-  '        <td>2</td>' +
-  '      </tr>' +
-  '    </tbody>' +
-  '  </table>' +
-  '</figure>';
+type TableFigureStyle = 'is-style-regular' | 'is-style-stripes';
+
+function tableContent(tableFigureStyle: TableFigureStyle) {
+  return (
+    `<figure class="wp-block-table ${tableFigureStyle}">` +
+    '  <table>' +
+    '    <thead>' +
+    '      <tr>' +
+    '        <th>Name</th>' +
+    '        <th>Species</th>' +
+    '        <th>Cover</th>' +
+    '        <th>Feet</th>' +
+    '      </tr>' +
+    '    </thead>' +
+    '    <tbody>' +
+    '      <tr>' +
+    '        <td>Ransu</td>' +
+    '        <td>Dog</td>' +
+    '        <td>Fur</td>' +
+    '        <td>4</td>' +
+    '      </tr>' +
+    '      <tr>' +
+    '        <td>Peto</td>' +
+    '        <td>Cat</td>' +
+    '        <td>Fur</td>' +
+    '        <td>4</td>' +
+    '      </tr>' +
+    '      <tr>' +
+    '        <td>Alex</td>' +
+    '        <td>Parrot</td>' +
+    '        <td>Feather</td>' +
+    '        <td>2</td>' +
+    '      </tr>' +
+    '    </tbody>' +
+    '  </table>' +
+    '</figure>'
+  );
+}
 
 export default {
   title: 'Common components/HtmlToReact',
@@ -51,11 +56,12 @@ export default {
     // Give some test content alternatives
     children: {
       control: 'select',
-      options: ['Iframes', 'KukkuuTestPage', 'TableTest'],
+      options: ['Iframes', 'KukkuuTestPage', 'RegularTable', 'StripesTable'],
       mapping: {
         Iframes: videoMediaIframeContent,
         KukkuuTestPage: kukkuuTestPage.page.content,
-        TableTest: tableContent,
+        RegularTable: tableContent('is-style-regular'),
+        StripesTable: tableContent('is-style-stripes'),
       },
     },
     tableVariants: {

--- a/src/common/components/htmlToReact/htmlToReact.module.scss
+++ b/src/common/components/htmlToReact/htmlToReact.module.scss
@@ -1,0 +1,7 @@
+@import '../../../core/styles/hdsCoreTable.module';
+
+.striped-figure {
+  table {
+    @extend .hds-table--zebra;
+  }
+}

--- a/src/core/pageContent/__mocks__/pageWithDiverseContent.mock.ts
+++ b/src/core/pageContent/__mocks__/pageWithDiverseContent.mock.ts
@@ -30,7 +30,48 @@ const pageWithDiverseContent: PageQuery['page'] = {
   <pre>function name() {
     return "Hello";
   }</pre>
-  <figure><table><thead><tr><th>Tämä on otsake 1</th><th>Otsake 2</th></tr></thead><tbody><tr><td>taulukon rivi 1 solu 1</td><td>solu 2</td></tr><tr><td>solu 1</td><td>taulukon rivi 2 solu 2</td></tr></tbody></table></figure>
+  <figure class="wp-block-table is-style-regular">
+    <table>
+      <caption>This is a regular style table</caption>
+      <thead>
+        <tr>
+          <th>Title 1</th>
+          <th>Title 2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Row 1 Cell 1 with <a href="https://hel.fi">Link</a></td>
+          <td>Row 1 Cell 2</td>
+        </tr>
+        <tr>
+          <td>Row 2 Cell 1</td>
+          <td>Row 2 Cell 2</td>
+        </tr>
+      </tbody>
+    </table>
+  </figure>
+  <figure class="wp-block-table is-style-stripes">
+    <table>
+      <caption>This is a stripes style table</caption>
+      <thead>
+        <tr>
+          <th>Title 1</th>
+          <th>Title 2</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Row 1 Cell 1 with <a href="https://hel.fi">Link</a></td>
+          <td>Row 1 Cell 2</td>
+        </tr>
+        <tr>
+          <td>Row 2 Cell 1</td>
+          <td>Row 2 Cell 2</td>
+        </tr>
+      </tbody>
+    </table>
+  </figure>
   <p><a href="https://hel.fi">Link</a></p>
   <p><abbr title="City of Helsinki">CoH</abbr></p>
   <p><b>Bold</b></p>

--- a/src/core/pageContent/pageMainContent.module.scss
+++ b/src/core/pageContent/pageMainContent.module.scss
@@ -22,36 +22,20 @@
       border-spacing: 0;
       border-collapse: collapse;
       background-color: transparent;
-      border-bottom: 1px solid var(--border-color-table);
 
       thead {
         display: table-header-group;
         vertical-align: middle;
-        border-color: var(--border-color-thead);
       }
 
       th {
-        border: 1px solid;
         padding: 0.5em;
-        border: 1px solid;
         word-break: normal;
       }
 
       td {
         padding: 0.5em;
-        border: 1px solid;
         word-break: normal;
-      }
-    }
-
-    &.is-style-stripes {
-      table {
-        td {
-          border-color: transparent !important;
-        }
-        tr.is-style-stripes {
-          background-color: #f0f0f0 !important;
-        }
       }
     }
   }

--- a/src/core/styles/hdsCoreTable.module.scss
+++ b/src/core/styles/hdsCoreTable.module.scss
@@ -1,0 +1,1 @@
+@import '~hds-core/lib/components/table/table';


### PR DESCRIPTION
## Description

### fix: fix table.css packaging, handle is-style-stripes style in figure

HtmlToReact:
 - add htmlToReact.module.scss for all the styles needed by HtmlToReact
 - wrap table.css from hds-core into hdsCoreTable.module.scss
 - map <figure class="is-style-stripes"> to .hds-table--zebra style in
   tables inside such figure
 - always pass options to domToReact calls
   - this makes it possible to move caption, thead and tbody tags'
	 handling into replaceDomNodeWithReactComponent because options has
	 replace function which uses replaceDomNodeWithReactComponent
 - add to classNames (i.e. merge) instead of overwriting them
 - add "with-vertical-lines" TableVariant

pageMainContent.module.scss:
 - remove border styles for tables, they now come from HtmlToReact

also:
 - set version to 1.0.0-alpha217
 - add more example data using tables to storybook stories

refs LIIKUNTA-466

## Issues

### Closes

**[LIIKUNTA-466](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-466)**

### Related

https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/500

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-466]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ