### PR TITLE
LIIKUNTA-466 | fix: fix HDS table padding by removing conflicting styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha217",
+  "version": "1.0.0-alpha218",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/pageContent/pageMainContent.module.scss
+++ b/src/core/pageContent/pageMainContent.module.scss
@@ -29,12 +29,10 @@
       }
 
       th {
-        padding: 0.5em;
         word-break: normal;
       }
 
       td {
-        padding: 0.5em;
         word-break: normal;
       }
     }


### PR DESCRIPTION
## Description

### fix: fix HDS table padding by removing conflicting styles

pageMainContent.module.scss:
 - remove conflicting paddings as they come from hds-core's table styles
   via HtmlToReact now

refs LIIKUNTA-466

## Issues

### Closes

**[LIIKUNTA-466](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-466)**

### Related

## Testing

**Showed to designer** in local environment and **they approved**

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-466]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ