### PR TITLE
feat: make header logo and universal bar primary link configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha230",
+  "version": "1.0.0-alpha231",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,2 @@
-export const CITY_OF_HELSINKI_WEBSITE_URL = 'https://www.hel.fi/';
 export const MAIN_CONTENT_ID = 'main-content';
 export const TOP_LEVEL_MENU_ITEM_PARENT_ID = 'null_parent_id' as const;

--- a/src/core/configProvider/configContext.ts
+++ b/src/core/configProvider/configContext.ts
@@ -11,18 +11,10 @@ import { EventType } from '../../common/eventsService/types';
 import { VenueType } from '../../common/venuesService/types';
 import type { CardProps } from '../card/Card';
 import { HtmlToReactProps } from '../../common/components/htmlToReact/HtmlToReact';
-
-export const FALLBACK_TRANSLATION_KEYS = [
-  'cityOfHelsinki',
-  'helsinki',
-  'helsinkiLogo',
-] as const;
-export type FallbackTranslationKey = (typeof FALLBACK_TRANSLATION_KEYS)[number];
-export type FallbackTranslation = Record<LanguageCodeEnum, string>;
-export type FallbackTranslations = Record<
-  FallbackTranslationKey,
-  FallbackTranslation
->;
+import {
+  FallbackTranslations,
+  OptionalTranslationsWithFallbacks,
+} from '../translation/types';
 
 export type Config = {
   siteName: string;
@@ -53,7 +45,7 @@ export type Config = {
       noResultsText: string;
       clearAll: string;
     };
-  };
+  } & OptionalTranslationsWithFallbacks;
   components: {
     A: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => JSX.Element;
     Img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => JSX.Element;

--- a/src/core/configProvider/defaultConfig.tsx
+++ b/src/core/configProvider/defaultConfig.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { logoFi, logoSv } from 'hds-react';
 
 import { ModuleItemTypeEnum } from '../../common/headlessService/constants';
 import { LanguageCodeEnum } from '../../common/headlessService/types';
@@ -10,6 +9,7 @@ import {
   getLocationCardProps,
 } from '../pageContent/utils';
 import { Config } from './configContext';
+import { FALLBACK_TRANSLATIONS } from '../translation/constants';
 
 export const defaultConfig: Config = {
   siteName: 'Test site',
@@ -24,23 +24,7 @@ export const defaultConfig: Config = {
   ],
   organisationPrefixes: [],
   // Here are the fallback translations for English/Finnish/Swedish:
-  fallbackTranslations: {
-    cityOfHelsinki: {
-      EN: 'City of Helsinki',
-      FI: 'Helsingin kaupunki',
-      SV: 'Helsingfors stad',
-    },
-    helsinki: {
-      EN: 'Helsinki',
-      FI: 'Helsinki',
-      SV: 'Helsingfors',
-    },
-    helsinkiLogo: {
-      EN: logoFi,
-      FI: logoFi,
-      SV: logoSv,
-    },
-  },
+  fallbackTranslations: FALLBACK_TRANSLATIONS,
   // Here are the current language's translations:
   // FIXME: "copy" should be renamed for clarity
   copy: {

--- a/src/core/navigation/Navigation.tsx
+++ b/src/core/navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { groupBy } from 'lodash-es';
-import { Header, LanguageOption, Logo, LogoProps } from 'hds-react';
+import { Header, LanguageOption, Logo } from 'hds-react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
 
@@ -9,10 +9,11 @@ import styles from './Navigation.module.scss';
 import { Language, Menu } from '../../common/headlessService/types';
 import { useConfig } from '../configProvider/useConfig';
 import {
-  CITY_OF_HELSINKI_WEBSITE_URL,
   MAIN_CONTENT_ID,
   TOP_LEVEL_MENU_ITEM_PARENT_ID,
 } from '../../common/constants';
+import { getTranslationWithFallback } from '../translation/getTranslationWithFallback';
+import { FallbackTranslationKey } from '../translation/types';
 
 type MenuItem = Omit<Menu['menuItems']['nodes'][0], '__typename'>;
 
@@ -106,14 +107,14 @@ export function Navigation({
   getPathnameForLanguage,
   getIsItemActive,
 }: NavigationProps) {
+  const config = useConfig();
   const {
     siteName,
     currentLanguageCode,
-    fallbackTranslations,
     copy: { menuToggleAriaLabel, skipToContentLabel },
     components: { A },
     utils: { getRoutedInternalHref },
-  } = useConfig();
+  } = config;
 
   // Language selection is required
   if (!languages || !languages.length) {
@@ -121,6 +122,8 @@ export function Navigation({
   }
 
   const currentLanguage = findLanguage(languages, currentLanguageCode);
+  const t = (field: FallbackTranslationKey) =>
+    getTranslationWithFallback(config, field, currentLanguageCode);
 
   // Error out if language props are inconsistent
   if (languages && !currentLanguage) {
@@ -142,15 +145,6 @@ export function Navigation({
       window.location.href = url;
     }
   };
-
-  const logoProps: LogoProps = {
-    size: 'large',
-    src: fallbackTranslations.helsinkiLogo[currentLanguageCode],
-    alt: fallbackTranslations.helsinki[currentLanguageCode],
-  };
-
-  const localizedCityOfHelsinki =
-    fallbackTranslations.cityOfHelsinki[currentLanguageCode];
 
   const menuItemChildren: MenuItemChildren = groupBy(
     menu?.menuItems?.nodes ?? [],
@@ -179,8 +173,8 @@ export function Navigation({
       />
       {universalBarMenu && (
         <Header.UniversalBar
-          primaryLinkText={localizedCityOfHelsinki}
-          primaryLinkHref={CITY_OF_HELSINKI_WEBSITE_URL}
+          primaryLinkText={t('headerUniversalBarPrimaryLinkText')}
+          primaryLinkHref={t('headerUniversalBarPrimaryLinkHref')}
         >
           {universalBarMenu?.menuItems?.nodes?.map((navigationItem) =>
             createMenuLinkElement({ ...sharedMenuLinkProps, navigationItem }),
@@ -195,8 +189,14 @@ export function Navigation({
         onTitleClick={onTitleClick}
         onLogoClick={onTitleClick}
         frontPageLabel={siteName}
-        logo={<Logo {...logoProps} />}
-        logoAriaLabel={localizedCityOfHelsinki}
+        logo={
+          <Logo
+            size="large"
+            src={t('headerActionBarLogoSrc')}
+            alt={t('headerActionBarLogoAlt')}
+          />
+        }
+        logoAriaLabel={t('headerActionBarLogoAriaLabel')}
       >
         <Header.LanguageSelector />
         {userNavigation && userNavigation}

--- a/src/core/translation/__tests__/getTranslationWithFallback.test.tsx
+++ b/src/core/translation/__tests__/getTranslationWithFallback.test.tsx
@@ -1,0 +1,36 @@
+import { FALLBACK_TRANSLATION_KEYS, FALLBACK_TRANSLATIONS } from '../constants';
+import { getTranslationWithFallback } from '../getTranslationWithFallback';
+import { defaultConfig } from '../../configProvider/defaultConfig';
+import { LanguageCodeEnum } from '../../../common/headlessService/__generated__';
+import { Config } from '../../configProvider/configContext';
+
+describe('getTranslationWithFallback', () => {
+  it.each(FALLBACK_TRANSLATION_KEYS)(
+    'if translation for field "%s" is given, its fallback translation is not used',
+    async (field) => {
+      const config: Config = {
+        ...defaultConfig,
+        copy: { ...defaultConfig.copy, [field]: 'test' },
+      };
+      Object.values(LanguageCodeEnum).forEach((languageCode) => {
+        expect(getTranslationWithFallback(config, field, languageCode)).toBe(
+          'test',
+        );
+      });
+    },
+  );
+
+  it.each(FALLBACK_TRANSLATION_KEYS)(
+    'if translation for field "%s" is not given, its fallback translation is used',
+    async (field) => {
+      const config: Config = { ...defaultConfig };
+      delete config.copy[field];
+      expect(config.copy[field]).toBeUndefined();
+      Object.values(LanguageCodeEnum).forEach((languageCode) => {
+        expect(getTranslationWithFallback(config, field, languageCode)).toBe(
+          FALLBACK_TRANSLATIONS[field][languageCode],
+        );
+      });
+    },
+  );
+});

--- a/src/core/translation/constants.ts
+++ b/src/core/translation/constants.ts
@@ -1,0 +1,41 @@
+import { logoFi, logoSv } from 'hds-react';
+
+export const FALLBACK_TRANSLATION_KEYS = [
+  'headerActionBarLogoAlt',
+  'headerActionBarLogoAriaLabel',
+  'headerActionBarLogoSrc',
+  'headerUniversalBarPrimaryLinkHref',
+  'headerUniversalBarPrimaryLinkText',
+] as const;
+
+export const CITY_OF_HELSINKI_TRANSLATIONS = {
+  EN: 'City of Helsinki',
+  FI: 'Helsingin kaupunki',
+  SV: 'Helsingfors stad',
+};
+
+export const HELSINKI_TRANSLATIONS = {
+  EN: 'Helsinki',
+  FI: 'Helsinki',
+  SV: 'Helsingfors',
+};
+
+export const LOCALIZED_HELSINKI_LOGO_SVG_CONTENTS = {
+  EN: logoFi,
+  FI: logoFi,
+  SV: logoSv,
+};
+
+export const LOCALIZED_HELSINKI_WEBSITE_URL = {
+  EN: 'https://www.hel.fi/en',
+  FI: 'https://www.hel.fi/fi',
+  SV: 'https://www.hel.fi/sv',
+};
+
+export const FALLBACK_TRANSLATIONS = {
+  headerActionBarLogoAlt: HELSINKI_TRANSLATIONS,
+  headerActionBarLogoAriaLabel: CITY_OF_HELSINKI_TRANSLATIONS,
+  headerActionBarLogoSrc: LOCALIZED_HELSINKI_LOGO_SVG_CONTENTS,
+  headerUniversalBarPrimaryLinkHref: LOCALIZED_HELSINKI_WEBSITE_URL,
+  headerUniversalBarPrimaryLinkText: CITY_OF_HELSINKI_TRANSLATIONS,
+};

--- a/src/core/translation/getTranslationWithFallback.ts
+++ b/src/core/translation/getTranslationWithFallback.ts
@@ -1,0 +1,9 @@
+import { LanguageCodeEnum } from '../../common/headlessService/__generated__';
+import { Config } from '../configProvider/configContext';
+import { FallbackTranslationKey } from './types';
+
+export const getTranslationWithFallback = (
+  config: Config,
+  field: FallbackTranslationKey,
+  language: LanguageCodeEnum,
+): string => config.copy[field] ?? config.fallbackTranslations[field][language];

--- a/src/core/translation/types.ts
+++ b/src/core/translation/types.ts
@@ -1,0 +1,12 @@
+import { LanguageCodeEnum } from '../../common/headlessService/__generated__';
+import { FALLBACK_TRANSLATION_KEYS } from './constants';
+
+export type FallbackTranslationKey = (typeof FALLBACK_TRANSLATION_KEYS)[number];
+export type FallbackTranslation = Record<LanguageCodeEnum, string>;
+export type FallbackTranslations = Record<
+  FallbackTranslationKey,
+  FallbackTranslation
+>;
+export type OptionalTranslationsWithFallbacks = {
+  [key in FallbackTranslationKey]?: string;
+};


### PR DESCRIPTION
## Description

### feat: make header logo and universal bar primary link configurable

add new config options under Config['copy']:
 - headerActionBarLogoAlt
 - headerActionBarLogoAriaLabel
 - headerActionBarLogoSrc
 - headerUniversalBarPrimaryLinkHref
   - add localized URL fallbacks for each language
 - headerUniversalBarPrimaryLinkText

also:
 - split translation functionality into separate files and add tests for
   getTranslationWithFallback
 - set version to 1.0.0-alpha231

refs LIIKUNTA-582, LIIKUNTA-585 (work leftover from these tickets)

## Issues

### Closes

### Related

[LIIKUNTA-582](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-582)
[LIIKUNTA-585](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-585)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[LIIKUNTA-582]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-585]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ