### PR TITLE
feat: add id, role and size attributes to the tag component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@
 module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
-
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: 'v8',
 
@@ -12,7 +11,7 @@ module.exports = {
   moduleNameMapper: {
     // return a mock css module
     '\\.(css|less|scss|sss|styl)$': 'identity-obj-proxy',
-     "^lodash-es$": "lodash"
+    '^lodash-es$': 'lodash',
   },
 
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha242",
+  "version": "1.0.0-alpha243",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/common/components/tag/Tag.tsx
+++ b/src/common/components/tag/Tag.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
 import { Tag as HDSTag } from 'hds-react';
+import type { TagProps as HDSTagProps } from 'hds-react';
 
 import styles from './tag.module.scss';
 import { theme1, theme2 } from './tagThemes';
@@ -13,7 +14,7 @@ type Props = {
   whiteOnly?: boolean;
   selected?: boolean;
   onClick?: () => void;
-};
+} & Pick<HDSTagProps, 'id' | 'role' | 'size'>;
 
 export function Tag({
   className,
@@ -22,7 +23,15 @@ export function Tag({
   selected,
   whiteOnly,
   onClick,
+  id,
+  ...hdsTagProps
 }: Props) {
+  /**
+   * @deprecated the generatedId won't be needed after HDS removes the default value from the HDS Tag component:
+   * https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/tag/Tag.tsx#L81).
+   * */
+  const generatedId = React.useId();
+
   const handleClick = (): void => {
     if (onClick) {
       onClick();
@@ -43,6 +52,9 @@ export function Tag({
         !onClick && styles.noOutline,
         className,
       )}
+      {...hdsTagProps}
+      // TODO: don't use the generatedId and allow an undefined id.
+      id={id ?? `tag${generatedId}`}
     >
       {children}
     </HDSTag>

--- a/src/common/components/tag/__tests__/Tag.test.tsx
+++ b/src/common/components/tag/__tests__/Tag.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Tag } from '../Tag';
+
+describe('Tag', () => {
+  it('should have an unique generated id if the id-attribute is unset', () => {
+    const listOfTags = Array.from('abcdefghijklmnopqrstuvwxyz').map((c) =>
+      React.createElement(Tag, undefined, c),
+    );
+    // Tag id is defined every time
+    expect(listOfTags.every((tag) => !!tag)).toBe(true);
+    // Every id is unique
+    expect([...new Set(listOfTags)]).toHaveLength(listOfTags.length);
+  });
+
+  it('should have settable id-property', () => {
+    const ids = Array.from('abcdefghijklmnopqrstuvwxyz');
+    const listOfTags = ids.map((c) =>
+      // eslint-disable-next-line react/no-children-prop
+      React.createElement(Tag, { id: c, children: c }),
+    );
+    // Tag id is defined every time
+    expect(
+      listOfTags.every(
+        (tag) =>
+          tag.props.id === tag.props.children && ids.includes(tag.props.id),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ES2020",
     "moduleResolution": "Node",
-    "target": "es5",
+    "target": "es2021",
     "lib": ["dom", "es2020"],
     "outDir": "lib",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
HH-305 LIIKUNTA-593. 
There are some values that should be overridable.
While the HDS Tag-component still has a default value for an ID-property, it needs to overridable and automatically generated, if unset.

The id parameter is already deprecated with default value.
See more: https://github.com/City-of-Helsinki/helsinki-design-system/blob/master/packages/react/src/components/tag/Tag.tsx#L81).