### PR TITLE
fix: skip collections' events by ids query when no ids are given

### DIFF
--- a/src/core/collection/Collection.tsx
+++ b/src/core/collection/Collection.tsx
@@ -313,6 +313,7 @@ export function EventSelectionCollection({
     client: eventsApolloClient !== 'disabled' && eventsApolloClient,
     ssr: false,
     notifyOnNetworkStatusChange: true,
+    skip: collection.events.length === 0,
     variables: {
       ids: collection.events,
       pageSize,

--- a/src/core/collection/__tests__/Collection.test.tsx
+++ b/src/core/collection/__tests__/Collection.test.tsx
@@ -65,6 +65,19 @@ describe('event selection module', () => {
     // so the amount of the links should be the amounts of events.
     expect(screen.getAllByRole('link').length).toBe(activeEvents.length);
   });
+
+  it('renders an empty collection when no event ids was given', async () => {
+    const collection = { events: [] } as EventSelectionCollectionType;
+    const { container } = render(
+      <EventSelectionCollection collection={collection} type="carousel" />,
+      undefined,
+      { ...getApolloConfig(CmsEndpoint.events) },
+    );
+    await waitFor(() => {
+      expect(screen.queryByText(/Page is loading/)).not.toBeInTheDocument();
+    });
+    expect(container.getElementsByTagName('ul')[0].children).toHaveLength(0);
+  });
 });
 
 describe('event search module', () => {


### PR DESCRIPTION
HCRC-89.
Skip events by ids query and render an empty collection when no event ids are given.
