### PR TITLE
LIIKUNTA-445 | feat(link): handle mailto: and tel: prefixed hrefs in <Link> specially

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha245",
+  "version": "1.0.0-alpha246",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/link/Link.stories.tsx
+++ b/src/core/link/Link.stories.tsx
@@ -32,6 +32,12 @@ const Template: StoryFn<typeof Link> = (args) => (
       <Link {...args} aria-label="Internal link default" href="/internal">
         Internal link default
       </Link>
+      <Link {...args} aria-label="Email link" href="mailto:test@example.org">
+        test@example.org
+      </Link>
+      <Link {...args} aria-label="Phone link" href="tel:+358 12 345 6789">
+        +358 12 345 6789
+      </Link>
       <SecondaryLink
         {...args}
         aria-label="External secondary"

--- a/src/core/link/Link.tsx
+++ b/src/core/link/Link.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
+import { IconEnvelope, IconPhone } from 'hds-react';
 
 import LinkBase from './LinkBase';
 import { useConfig } from '../configProvider/useConfig';
@@ -32,6 +33,7 @@ export function Link({
   openInNewTab,
   className,
   size = 'M',
+  iconRight,
   ...delegatedProps
 }: LinkProps) {
   const {
@@ -40,7 +42,10 @@ export function Link({
     copy: { openInExternalDomainAriaLabel, openInNewTabAriaLabel },
   } = useConfig();
 
-  const isExternal = getIsHrefExternal(href);
+  const isEmail = href?.startsWith('mailto:') || undefined;
+  const isPhone = href?.startsWith('tel:') || undefined;
+  const isExternal = getIsHrefExternal(href) && !isEmail && !isPhone;
+  const iconSize = size === 'S' ? 'xs' : 's';
 
   const linkComponent = (
     <LinkBase
@@ -53,6 +58,11 @@ export function Link({
       className={classNames(styles.link, className)}
       openInExternalDomainAriaLabel={openInExternalDomainAriaLabel}
       openInNewTabAriaLabel={openInNewTabAriaLabel}
+      iconRight={
+        iconRight ??
+        (isEmail && <IconEnvelope size={iconSize} aria-hidden />) ??
+        (isPhone && <IconPhone size={iconSize} aria-hidden />)
+      }
       disableVisitedStyles
     >
       {children ?? ''}

--- a/src/core/link/LinkBase.module.scss
+++ b/src/core/link/LinkBase.module.scss
@@ -10,6 +10,10 @@
   composes: hds-icon-left from './LinkBase.scss';
 }
 
+.iconRight {
+  composes: hds-icon-right from './LinkBase.scss';
+}
+
 .verticalAlignSmallOrMediumIcon {
   composes: vertical-align-small-or-medium-icon from './LinkBase.scss';
 }

--- a/src/core/link/LinkBase.scss
+++ b/src/core/link/LinkBase.scss
@@ -89,6 +89,6 @@
 }
 
 .hds-link--large .hds-icon-right {
-  margin-left: 16px;
+  margin-left: 0; /* 16px i.e. .hds-icon-left's margin-right value would be too much */
   vertical-align: middle;
 }


### PR DESCRIPTION
## Description

### feat(link): handle `mailto:` and `tel:` prefixed hrefs in `<Link>` specially

 - `mailto:` prefixed hrefs in `<Link>` use envelope icon to indicate email
 - `tel:` prefixed hrefs in `<Link>` use phone icon to indicate telephone

also:
 - fix `iconRight` style, it was not working at all before,
   not it works similarly as `.hds-icon-left` but on the other side of
   the link, except but had to make the large link's right icon's margin
   zero to not make the margin too big
 - set version to 1.0.0-alpha246

refs LIIKUNTA-445

## Issues

### Closes

### Related

[LIIKUNTA-445](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-445)

## Testing

### Automated tests

### Manual testing

## Screenshots

### Added examples of phone & email link to storybook
![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/7a487261-c53b-42a0-9362-9e0b37a1e384)

### Default size
![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/3c276045-9eda-4649-8ff7-c0b7a4617422)

### Size S
![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/2ea71bae-9f03-428c-9fd9-ad9645e2f512)

### Size M
![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/faad70d2-711e-448f-8aa8-01cdc4947107)

### Size L
![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/e5b4a5e5-ab65-481d-a0b9-3cf149bccffc)

## Additional notes

[LIIKUNTA-445]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ