### PR TITLE
LIIKUNTA-445 | test: test email link uses envelope icon, phone link uses phone icon

### DIFF
--- a/src/core/link/__tests__/Link.test.tsx
+++ b/src/core/link/__tests__/Link.test.tsx
@@ -45,6 +45,26 @@ test('renders external link without external icon', () => {
   expect(screen.getByRole('link').lastChild.nodeName).not.toEqual('svg');
 });
 
+test('renders email link with envelope icon', () => {
+  render(<Link href="mailto:test@example.org">test@example.org</Link>);
+  const linkLastChild = screen.getByRole('link').lastChild;
+  expect(linkLastChild.nodeName).toEqual('SPAN');
+  const span = linkLastChild as HTMLSpanElement;
+  expect(span.lastChild.nodeName).toEqual('svg');
+  const svg = span.lastChild as SVGSVGElement;
+  expect(svg).toHaveAttribute('aria-label', 'envelope');
+});
+
+test('renders phone link with phone icon', () => {
+  render(<Link href="tel:+358 12 345 789">+358 12 345 789</Link>);
+  const linkLastChild = screen.getByRole('link').lastChild;
+  expect(linkLastChild.nodeName).toEqual('SPAN');
+  const span = linkLastChild as HTMLSpanElement;
+  expect(span.lastChild.nodeName).toEqual('svg');
+  const svg = span.lastChild as SVGSVGElement;
+  expect(svg).toHaveAttribute('aria-label', 'phone');
+});
+
 test('renders external link which opens in a new tab by default', () => {
   render(<Link href="https://www.google.com/">Search from google</Link>);
   const link = screen.getByRole('link', {


### PR DESCRIPTION
## Description

### test: test email link uses envelope icon, phone link uses phone icon

refs LIIKUNTA-445 (Tests mentioned to be done later in PR #152 comment)

## Issues

### Closes

### Related

[LIIKUNTA-445](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-445)
https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/152#issuecomment-1878293132

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
