### PR TITLE
Articles search query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha246",
+  "version": "1.0.0-alpha247",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -120,6 +120,7 @@ export interface SearchPageContentProps {
   className?: string;
   tags?: SearchTag[];
   currentTags?: SearchTag[];
+  withQuery?: boolean;
   currentText?: string;
   largeFirstItem?: boolean;
   onSearch?: (freeSearch: string, tags: SearchTag[]) => void;
@@ -172,6 +173,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
     tags,
     currentTags,
     currentText,
+    withQuery,
     onSearch,
     onLoadMore,
     page,
@@ -186,11 +188,13 @@ export function SearchPageContent(props: SearchPageContentProps) {
   const [searchTags, setSearchTags] = useState<SearchTag[]>([]);
 
   useEffect(() => {
-    if (currentTags.length > 0) {
-      setSearchTags(currentTags);
+    if (withQuery) {
+      if (currentTags.length > 0) {
+        setSearchTags(currentTags);
+      }
+      setSearchText(currentText);
     }
-    setSearchText(currentText);
-  }, [currentTags, currentText]);
+  }, [currentTags, currentText, withQuery]);
 
   const handleSearch = (e: React.FormEvent): void => {
     e.preventDefault();

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import classNames from 'classnames';
 import {
@@ -120,6 +120,7 @@ export interface SearchPageContentProps {
   className?: string;
   tags?: SearchTag[];
   currentTags?: SearchTag[];
+  currentText?: string;
   largeFirstItem?: boolean;
   onSearch?: (freeSearch: string, tags: SearchTag[]) => void;
   onLoadMore?: () => void;
@@ -170,6 +171,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
     noResults,
     tags,
     currentTags,
+    currentText,
     onSearch,
     onLoadMore,
     page,
@@ -181,7 +183,14 @@ export function SearchPageContent(props: SearchPageContentProps) {
   } = useConfig();
 
   const [searchText, setSearchText] = useState<string>('');
-  const [searchTags, setSearchTags] = useState<SearchTag[]>(currentTags);
+  const [searchTags, setSearchTags] = useState<SearchTag[]>([]);
+
+  useEffect(() => {
+    if (currentTags.length > 0) {
+      setSearchTags(currentTags);
+    }
+    setSearchText(currentText);
+  }, [currentTags, currentText]);
 
   const handleSearch = (e: React.FormEvent): void => {
     e.preventDefault();

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -202,15 +202,19 @@ export function SearchPageContent(props: SearchPageContentProps) {
   };
 
   const handleTagClick = (tag: SearchTag) => (): void => {
-    let selectedTags = [...searchTags];
-    if (selectedTags.includes(tag)) {
-      selectedTags = selectedTags.filter((selectedTag) => selectedTag !== tag);
-    } else {
-      selectedTags = [...selectedTags, tag];
-    }
+    if (!isLoading) {
+      let selectedTags = [...searchTags];
+      if (selectedTags.includes(tag)) {
+        selectedTags = selectedTags.filter(
+          (selectedTag) => selectedTag !== tag,
+        );
+      } else {
+        selectedTags = [...selectedTags, tag];
+      }
 
-    setSearchTags([...selectedTags]);
-    onSearch(searchText, selectedTags);
+      setSearchTags([...selectedTags]);
+      onSearch(searchText, selectedTags);
+    }
   };
 
   const clearTags = (): void => {

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -248,7 +248,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
             {tags && (
               <SearchTags
                 tags={tags}
-                hasClearSearch={Boolean(searchText) && tags.length > 0}
+                hasClearSearch={Boolean(searchText) && currentTags.length > 0}
                 clearAllText={archiveSearch?.clearAll}
                 currentTags={searchTags}
                 handleTagClick={handleTagClick}

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -119,6 +119,7 @@ export interface SearchPageContentProps {
   noResults?: boolean;
   className?: string;
   tags?: SearchTag[];
+  currentTags?: SearchTag[];
   largeFirstItem?: boolean;
   onSearch?: (freeSearch: string, tags: SearchTag[]) => void;
   onLoadMore?: () => void;
@@ -168,6 +169,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
     isLoading,
     noResults,
     tags,
+    currentTags,
     onSearch,
     onLoadMore,
     page,
@@ -179,7 +181,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
   } = useConfig();
 
   const [searchText, setSearchText] = useState<string>('');
-  const [searchTags, setSearchTags] = useState<SearchTag[]>([]);
+  const [searchTags, setSearchTags] = useState<SearchTag[]>(currentTags);
 
   const handleSearch = (e: React.FormEvent): void => {
     e.preventDefault();
@@ -191,15 +193,15 @@ export function SearchPageContent(props: SearchPageContentProps) {
   };
 
   const handleTagClick = (tag: SearchTag) => (): void => {
-    let currentTags = [...searchTags];
-    if (currentTags.includes(tag)) {
-      currentTags = currentTags.filter((selectedTag) => selectedTag !== tag);
+    let selectedTags = [...searchTags];
+    if (selectedTags.includes(tag)) {
+      selectedTags = selectedTags.filter((selectedTag) => selectedTag !== tag);
     } else {
-      currentTags = [...currentTags, tag];
+      selectedTags = [...selectedTags, tag];
     }
 
-    setSearchTags([...currentTags]);
-    onSearch(searchText, currentTags);
+    setSearchTags([...selectedTags]);
+    onSearch(searchText, selectedTags);
   };
 
   const clearTags = (): void => {
@@ -230,7 +232,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
                 searchText={searchText}
               />
             </div>
-            {tags && (
+            {!isLoading && tags && (
               <SearchTags
                 tags={tags}
                 hasClearSearch={Boolean(searchText) && tags.length > 0}

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -252,7 +252,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
             {tags && (
               <SearchTags
                 tags={tags}
-                hasClearSearch={Boolean(searchText) && currentTags.length > 0}
+                hasClearSearch={Boolean(searchText) || currentTags.length > 0}
                 clearAllText={archiveSearch?.clearAll}
                 currentTags={searchTags}
                 handleTagClick={handleTagClick}

--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -241,7 +241,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
                 searchText={searchText}
               />
             </div>
-            {!isLoading && tags && (
+            {tags && (
               <SearchTags
                 tags={tags}
                 hasClearSearch={Boolean(searchText) && tags.length > 0}

--- a/src/core/configProvider/configContext.ts
+++ b/src/core/configProvider/configContext.ts
@@ -75,6 +75,7 @@ export type Config = {
       type?: ModuleItemTypeEnum,
     ) => string;
     redirectToUrl: (url: string) => void;
+    redirectToArticlesSearch?: (tag: string) => void;
   };
   meta?: {
     appleTouchIconUrl?: string;

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -123,7 +123,7 @@ export const defaultContentModules = (
 
 export const defaultContent = (
   page: PageType | ArticleType,
-  onArticlesSearch: (tag: string) => void,
+  onArticlesSearch?: (tag: string) => void,
 ) => {
   let hideTitle = false;
   if (isPageType(page)) {

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -58,6 +58,7 @@ export type PageContentProps = {
   sidebarContentProps?: Partial<typeof SidebarContent>;
   PageContentLayoutComponent?: typeof PageContentLayout;
   className?: string;
+  onArticlesSearch?: (tag: string) => void;
   // All other props
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [x: string]: any;
@@ -120,7 +121,10 @@ export const defaultContentModules = (
   return contentModules;
 };
 
-export const defaultContent = (page: PageType | ArticleType) => {
+export const defaultContent = (
+  page: PageType | ArticleType,
+  onArticlesSearch: (tag: string) => void,
+) => {
   let hideTitle = false;
   if (isPageType(page)) {
     hideTitle = Boolean(page?.hero?.title);
@@ -133,6 +137,7 @@ export const defaultContent = (page: PageType | ArticleType) => {
       date={(page as ArticleType)?.date}
       categories={(page as ArticleType)?.categories}
       contentModules={defaultContentModules(page)}
+      onArticlesSearch
     />
   );
 };
@@ -209,6 +214,7 @@ export function PageContent(props: PageContentProps) {
     content,
     shareLinks,
     className,
+    onArticlesSearch,
     ...pageContentLayoutProps
   } = props;
 
@@ -261,7 +267,7 @@ export function PageContent(props: PageContentProps) {
         content={
           typeof content === 'function'
             ? content(page)
-            : content ?? defaultContent(page)
+            : content ?? defaultContent(page, onArticlesSearch)
         }
         shareLinks={shareLinks}
         collections={

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -137,7 +137,7 @@ export const defaultContent = (
       date={(page as ArticleType)?.date}
       categories={(page as ArticleType)?.categories}
       contentModules={defaultContentModules(page)}
-      onArticlesSearch
+      onArticlesSearch={onArticlesSearch}
     />
   );
 };

--- a/src/core/pageContent/PageMainContent.tsx
+++ b/src/core/pageContent/PageMainContent.tsx
@@ -26,6 +26,7 @@ export function PageMainContent({
 }: PageMainContentProps) {
   const {
     htmlSanitizer: { allowedUnsafeTags, trustedOrigins },
+    utils: { redirectToArticlesSearch },
   } = useConfig();
 
   return (
@@ -43,7 +44,17 @@ export function PageMainContent({
             </div>
           )}
           {categories?.edges?.map((category) => (
-            <Tag className={styles.tag} key={category.node?.id}>
+            <Tag
+              className={styles.tag}
+              key={category.node?.id}
+              onClick={
+                redirectToArticlesSearch
+                  ? () => {
+                      redirectToArticlesSearch(category.node?.id);
+                    }
+                  : null
+              }
+            >
               {category.node?.name}
             </Tag>
           ))}

--- a/src/core/pageContent/PageMainContent.tsx
+++ b/src/core/pageContent/PageMainContent.tsx
@@ -15,6 +15,7 @@ export type PageMainContentProps = {
   date?: string;
   categories?: ArticleType['categories'];
   contentModules?: React.ReactNode[];
+  onArticlesSearch?: (tag: string) => void;
 };
 
 export function PageMainContent({
@@ -23,10 +24,10 @@ export function PageMainContent({
   date,
   categories,
   contentModules,
+  onArticlesSearch,
 }: PageMainContentProps) {
   const {
     htmlSanitizer: { allowedUnsafeTags, trustedOrigins },
-    utils: { redirectToArticlesSearch },
   } = useConfig();
 
   return (
@@ -48,9 +49,9 @@ export function PageMainContent({
               className={styles.tag}
               key={category.node?.id}
               onClick={
-                redirectToArticlesSearch
+                onArticlesSearch
                   ? () => {
-                      redirectToArticlesSearch(category.node?.id);
+                      onArticlesSearch(category.node?.id);
                     }
                   : null
               }


### PR DESCRIPTION
## Description
- In all 3 apps article search now works with search query params (even though hcrc supports both state and url params search)
- Article page tags are redirecting to the article search with tag parameter (if app configured to use search query params, otherwise tags are not clickable)
- Fixed bug with clear search parameter

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
