### PR TITLE
HH-189 | fix: fix calling getEventCardProps with wrong parameters

### DIFF
--- a/src/core/collection/Collection.stories.tsx
+++ b/src/core/collection/Collection.stories.tsx
@@ -40,12 +40,13 @@ const Template: StoryFn<typeof Collection> = (args) => (
 const collection = getCollections([
   page?.modules[0],
 ])[0] as GeneralCollectionType;
+const organisationPrefixes = [...defaultConfig.organisationPrefixes];
 const cards = [
-  ...getCollectionCards(collection),
-  ...getCollectionCards(collection),
-  ...getCollectionCards(collection),
-  ...getCollectionCards(collection),
-  ...getCollectionCards(collection),
+  ...getCollectionCards(collection, organisationPrefixes),
+  ...getCollectionCards(collection, organisationPrefixes),
+  ...getCollectionCards(collection, organisationPrefixes),
+  ...getCollectionCards(collection, organisationPrefixes),
+  ...getCollectionCards(collection, organisationPrefixes),
 ].map((cardProps, index) => (
   <Card
     key={`${cardProps.id}-${index.toString()}`}

--- a/src/core/page/Page.stories.tsx
+++ b/src/core/page/Page.stories.tsx
@@ -120,20 +120,20 @@ export const PageDefault = {
             title={collection.title}
             collectionContainerProps={{ withDots: false }}
             type={getCollectionUIType(collection)}
-            cards={getCollectionCards(collection as GeneralCollectionType).map(
-              (cardProps) => (
-                <Card
-                  key={cardProps.id}
-                  {...cardProps}
-                  imageUrl={
-                    cardProps.imageUrl ||
-                    pageMock.featuredImage?.node?.mediaItemUrl
-                  }
-                  direction="fixed-vertical"
-                  clampText
-                />
-              ),
-            )}
+            cards={getCollectionCards(collection as GeneralCollectionType, [
+              ...defaultConfig.organisationPrefixes,
+            ]).map((cardProps) => (
+              <Card
+                key={cardProps.id}
+                {...cardProps}
+                imageUrl={
+                  cardProps.imageUrl ||
+                  pageMock.featuredImage?.node?.mediaItemUrl
+                }
+                direction="fixed-vertical"
+                clampText
+              />
+            ))}
           />
         ))}
       />

--- a/src/core/pageContent/PageContent.stories.tsx
+++ b/src/core/pageContent/PageContent.stories.tsx
@@ -97,7 +97,9 @@ export const PageContentWithFunctions = {
           <Collection
             key={`collection-${Math.random()}`}
             title={`${collection.title} (created with a custom function)`}
-            cards={getCollectionCards(collection).map((cardProps) => (
+            cards={getCollectionCards(collection, [
+              ...defaultConfig.organisationPrefixes,
+            ]).map((cardProps) => (
               <Card
                 key={cardProps.id}
                 {...cardProps}

--- a/src/core/pageContent/utils.ts
+++ b/src/core/pageContent/utils.ts
@@ -107,8 +107,8 @@ export function getArticlePageCardProps(
 
 export function getEventCardProps(
   item: EventType,
-  organisationPrefixes,
-  locale = DEFAULT_LOCALE,
+  organisationPrefixes: string[],
+  locale: string = DEFAULT_LOCALE,
 ): CardProps {
   const image = item.images.length > 0 ? item.images[0] : null;
   const name = item.name[locale.toLowerCase()] ?? item.name[DEFAULT_LOCALE];
@@ -151,12 +151,14 @@ export function getLocationCardProps(item: VenueType): CardProps {
 
 export function getCollectionCards(
   collection: GeneralCollectionType,
-  locale = DEFAULT_LOCALE,
+  organisationPrefixes: string[],
+  locale: string = DEFAULT_LOCALE,
 ): CardProps[] {
   return collection.items.reduce((result: CardProps[], item) => {
     if (isPageType(item) || isArticleType(item))
       result.push(getArticlePageCardProps(item));
-    else if (isEventType(item)) result.push(getEventCardProps(item, locale));
+    else if (isEventType(item))
+      result.push(getEventCardProps(item, organisationPrefixes, locale));
     else if (isVenueType(item)) result.push(getLocationCardProps(item));
     return result;
   }, []);


### PR DESCRIPTION
## Description

### fix: fix calling getEventCardProps with wrong parameters

noticed getEventCardProps parameter count difference in events-helsinki-monorepo when fixing types:
 - https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/607

refs HH-189

## Issues

### Closes

### Related

- [HH-189](https://helsinkisolutionoffice.atlassian.net/browse/HH-189)
- https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/607

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[HH-189]: https://helsinkisolutionoffice.atlassian.net/browse/HH-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ