### PR TITLE
fix: use mainContentId from Config in Navigation, use ?? instead of ||

### DIFF
--- a/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
+++ b/src/core/archiveSearchPageContent/ArchiveSearchPageContent.tsx
@@ -24,6 +24,7 @@ import {
   SearchTag,
 } from '../../common/headlessService/types';
 import { PageMeta } from '../pageContent/meta/PageMeta';
+import { MAIN_CONTENT_ID } from '../../common/constants';
 
 export function SearchForm({
   archiveSearch,
@@ -229,7 +230,7 @@ export function SearchPageContent(props: SearchPageContentProps) {
 
   return (
     <main
-      id={mainContentId || 'main-content'}
+      id={mainContentId ?? MAIN_CONTENT_ID}
       className={classNames(styles.contentLayout, className)}
     >
       {Head && <PageMeta headComponent={Head} page={page} />}

--- a/src/core/navigation/Navigation.tsx
+++ b/src/core/navigation/Navigation.tsx
@@ -116,6 +116,7 @@ export function Navigation({
     currentLanguageCode,
     copy: { menuToggleAriaLabel, skipToContentLabel },
     components: { A },
+    mainContentId,
     utils: { getRoutedInternalHref },
   } = config;
 
@@ -183,7 +184,7 @@ export function Navigation({
       className={classNames(className, styles.maxWidthXl)}
     >
       <Header.SkipLink
-        skipTo={`#${MAIN_CONTENT_ID}`}
+        skipTo={`#${mainContentId ?? MAIN_CONTENT_ID}`}
         label={skipToContentLabel}
       />
       {universalBarMenu && (

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -40,6 +40,7 @@ import { CardsModule } from '../pageModules/CardsModule/CardsModule';
 import { ImageModule } from '../pageModules/ImageModule/ImageModule';
 import { StepsModule } from '../pageModules/StepsModule/StepsModule';
 import createHashKey from '../utils/createHashKey';
+import { MAIN_CONTENT_ID } from '../../common/constants';
 
 export type PageContentProps = {
   page?: PageType | ArticleType;
@@ -247,7 +248,7 @@ export function PageContent(props: PageContentProps) {
 
   return (
     <main
-      id={mainContentId || 'main-content'}
+      id={mainContentId ?? MAIN_CONTENT_ID}
       className={classNames('page-main-content', className)}
     >
       {Head && <PageMeta headComponent={Head} page={page} />}


### PR DESCRIPTION
## Description

### fix: use mainContentId from Config in Navigation, use ?? instead of ||

refs KK-1069 (noticed mainContentId not being used in Navigation)

## Issues

### Closes

### Related

[KK-1069](https://helsinkisolutionoffice.atlassian.net/browse/KK-1069)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[KK-1069]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ