### PR TITLE
Image link should not render the external link icon by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha250",
+  "version": "1.0.0-alpha251",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/link/Link.module.scss
+++ b/src/core/link/Link.module.scss
@@ -28,3 +28,7 @@
     fill: var(--color-coat-of-arms-dark);
   }
 }
+
+.imgLink img {
+  display: block;
+}

--- a/src/core/link/Link.module.scss
+++ b/src/core/link/Link.module.scss
@@ -27,10 +27,4 @@
   &:visited svg g path {
     fill: var(--color-coat-of-arms-dark);
   }
-
-  span {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
 }

--- a/src/core/link/Link.stories.tsx
+++ b/src/core/link/Link.stories.tsx
@@ -44,11 +44,13 @@ const Template: StoryFn<typeof Link> = (args) => (
         href="https://hel.fi"
       >
         External link with an image
-        <img
-          src="https://upload.wikimedia.org/wikipedia/commons/b/b2/City_Branding_of_Helsinki.svg"
-          alt="City of Helsinki logo"
-          width="200px"
-        />
+        <span>
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/b/b2/City_Branding_of_Helsinki.svg"
+            alt="City of Helsinki logo"
+            width="200px"
+          />
+        </span>
       </Link>
       <SecondaryLink
         {...args}

--- a/src/core/link/Link.stories.tsx
+++ b/src/core/link/Link.stories.tsx
@@ -27,7 +27,7 @@ const Template: StoryFn<typeof Link> = (args) => (
   >
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <Link {...args} aria-label="External link" href="https://hel.fi">
-        Externnal link
+        External link
       </Link>
       <Link {...args} aria-label="Internal link default" href="/internal">
         Internal link default
@@ -37,6 +37,18 @@ const Template: StoryFn<typeof Link> = (args) => (
       </Link>
       <Link {...args} aria-label="Phone link" href="tel:+358 12 345 6789">
         +358 12 345 6789
+      </Link>
+      <Link
+        {...args}
+        aria-label="External link with an image"
+        href="https://hel.fi"
+      >
+        External link with an image
+        <img
+          src="https://upload.wikimedia.org/wikipedia/commons/b/b2/City_Branding_of_Helsinki.svg"
+          alt="City of Helsinki logo"
+          width="200px"
+        />
       </Link>
       <SecondaryLink
         {...args}
@@ -59,6 +71,18 @@ const Template: StoryFn<typeof Link> = (args) => (
         variant="arrowRight"
       >
         Secondary Internal link with arrow right
+      </SecondaryLink>
+      <SecondaryLink
+        {...args}
+        aria-label="External SecondaryLink with an image"
+        href="https://hel.fi"
+      >
+        External secondary link with an image
+        <img
+          src="https://upload.wikimedia.org/wikipedia/commons/b/b2/City_Branding_of_Helsinki.svg"
+          alt="City of Helsinki logo"
+          width="200px"
+        />
       </SecondaryLink>
     </div>
   </ConfigProvider>

--- a/src/core/link/Link.tsx
+++ b/src/core/link/Link.tsx
@@ -7,7 +7,7 @@ import { IconEnvelope, IconPhone } from 'hds-react';
 import LinkBase from './LinkBase';
 import { useConfig } from '../configProvider/useConfig';
 import styles from './Link.module.scss';
-import { getChildrenByType } from '../utils/getChildrenByType';
+import { findAllElementsOfType } from '../utils/findAllElementsOfType';
 
 export type LinkProps = Omit<
   React.ComponentPropsWithoutRef<'a'>,
@@ -47,7 +47,7 @@ export function Link({
   const isPhone = href?.startsWith('tel:') || undefined;
   const isExternal = getIsHrefExternal(href) && !isEmail && !isPhone;
   const iconSize = size === 'S' ? 'xs' : 's';
-  const hasImageInLink = getChildrenByType(children, ['img']).length > 0;
+  const hasImageInLink = findAllElementsOfType(children, ['img']).length > 0;
   // The external links should always open in a new tab.
   const openInNewTab = forceOpenInNewTab ?? isExternal;
   // If the link contains an image, the external icon should be hidden by default,

--- a/src/core/link/Link.tsx
+++ b/src/core/link/Link.tsx
@@ -7,6 +7,7 @@ import { IconEnvelope, IconPhone } from 'hds-react';
 import LinkBase from './LinkBase';
 import { useConfig } from '../configProvider/useConfig';
 import styles from './Link.module.scss';
+import { getChildrenByType } from '../utils/getChildrenByType';
 
 export type LinkProps = Omit<
   React.ComponentPropsWithoutRef<'a'>,
@@ -29,8 +30,8 @@ export type LinkProps = Omit<
 export function Link({
   href,
   children,
-  showExternalIcon,
-  openInNewTab,
+  showExternalIcon: forceShowExternalIcon,
+  openInNewTab: forceOpenInNewTab,
   className,
   size = 'M',
   iconRight,
@@ -46,16 +47,24 @@ export function Link({
   const isPhone = href?.startsWith('tel:') || undefined;
   const isExternal = getIsHrefExternal(href) && !isEmail && !isPhone;
   const iconSize = size === 'S' ? 'xs' : 's';
-
+  const hasImageInLink = getChildrenByType(children, ['img']).length > 0;
+  // The external links should always open in a new tab.
+  const openInNewTab = forceOpenInNewTab ?? isExternal;
+  // If the link contains an image, the external icon should be hidden by default,
+  // because an icon next to image does not look good.
+  const showExternalIcon =
+    forceShowExternalIcon ?? (isExternal && !hasImageInLink);
   const linkComponent = (
     <LinkBase
       size={size}
       {...delegatedProps}
       href={href}
-      openInNewTab={openInNewTab ?? isExternal}
+      openInNewTab={openInNewTab}
       external={isExternal}
-      showExternalIcon={showExternalIcon ?? isExternal}
-      className={classNames(styles.link, className)}
+      showExternalIcon={showExternalIcon}
+      className={classNames(styles.link, className, {
+        [styles.imgLink]: hasImageInLink,
+      })}
       openInExternalDomainAriaLabel={openInExternalDomainAriaLabel}
       openInNewTabAriaLabel={openInNewTabAriaLabel}
       iconRight={

--- a/src/core/link/__tests__/Link.test.tsx
+++ b/src/core/link/__tests__/Link.test.tsx
@@ -98,3 +98,15 @@ test('renders internal link with specified screen reader text', () => {
     screen.getByRole('link', { name: 'This is for screen reader' }),
   ).toBeInTheDocument();
 });
+
+test('the link with image should not show an external icon by default', () => {
+  const { container } = render(
+    <Link href="https://www.google.com/">
+      Text for an external link with image
+      <img src="#" alt="this is an img inside an external link" />
+    </Link>,
+  );
+  expect(container.childElementCount).toBe(1);
+  expect(container.lastChild.nodeName).not.toEqual('svg');
+  expect(container).toMatchSnapshot();
+});

--- a/src/core/link/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/src/core/link/__tests__/__snapshots__/Link.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the link with image should not show an external icon by default 1`] = `
+<div>
+  <a
+    aria-label="Text for an external link with image. Opens in a new tab. Opens a different website."
+    class="link linkM disableVisitedStyles link imgLink"
+    href="https://www.google.com/"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      class="content"
+    >
+      Text for an external link with image
+      <img
+        alt="this is an img inside an external link"
+        src="#"
+      />
+    </span>
+  </a>
+</div>
+`;

--- a/src/core/utils/__tests__/__snapshots__/findAllElementsOfType.test.tsx.snap
+++ b/src/core/utils/__tests__/__snapshots__/findAllElementsOfType.test.tsx.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`findAllElementsOfType finds the elements of searched types # 1`] = `
+[
+  <li>
+    Should be included 1/2
+  </li>,
+  <li>
+    Should be included 2/2
+  </li>,
+]
+`;
+
+exports[`findAllElementsOfType finds the elements of searched types # 2`] = `
+[
+  <li>
+    Should be included 1/3
+  </li>,
+  <li>
+    Should be included 2/3
+  </li>,
+  <li>
+    Should be included 3/3
+  </li>,
+]
+`;
+
+exports[`findAllElementsOfType finds the elements of searched types # 3`] = `
+[
+  <li>
+    Should be included 1/3
+  </li>,
+  <ul>
+    <li>
+      Should be included 1/3
+    </li>
+  </ul>,
+  <li>
+    Should be included 2/3
+  </li>,
+  <li>
+    Should be included 3/3
+  </li>,
+  <ol>
+    <li>
+      Should be included 2/3
+    </li>
+    <li>
+      Should be included 3/3
+    </li>
+  </ol>,
+]
+`;
+
+exports[`findAllElementsOfType finds the elements of searched types # 4`] = `
+[
+  <li>
+    Should be included 1/3
+  </li>,
+  <li>
+    Should be included 2/3
+  </li>,
+  <li>
+    Should be included 3/3
+  </li>,
+]
+`;
+
+exports[`findAllElementsOfType finds the elements of searched types # 5`] = `
+[
+  <img
+    alt="should be included 1/2"
+    src="#"
+  />,
+  <img
+    alt="should be included 2/2"
+    src="#"
+  />,
+]
+`;

--- a/src/core/utils/__tests__/__snapshots__/getChildrenByType.test.tsx.snap
+++ b/src/core/utils/__tests__/__snapshots__/getChildrenByType.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getChildrenByType filters childrens by defined list of types 1`] = `
+[
+  <p>
+    should contain 1/3
+  </p>,
+  <img
+    alt="should contain 2/3"
+    src="#"
+  />,
+  <p>
+    should contain 3/3
+  </p>,
+]
+`;
+
+exports[`getChildrenByType filters childrens by defined list of types 2`] = `
+[
+  <ul>
+    <li>
+      Should contain 1/2
+    </li>
+  </ul>,
+  <ul>
+    <li>
+      Should contain 2/2
+    </li>
+  </ul>,
+]
+`;

--- a/src/core/utils/__tests__/__snapshots__/recursiveMap.test.tsx.snap
+++ b/src/core/utils/__tests__/__snapshots__/recursiveMap.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`recursiveMap can be used to modify each children of a React node 1`] = `
+[
+  <div
+    className="newTestClassInEveryElement"
+  >
+    A
+  </div>,
+  <div
+    className="newTestClassInEveryElement"
+  >
+    <div
+      className="newTestClassInEveryElement"
+    >
+      B
+    </div>
+  </div>,
+  <div
+    className="newTestClassInEveryElement"
+  >
+    <div
+      className="newTestClassInEveryElement"
+    >
+      <div
+        className="newTestClassInEveryElement"
+      >
+        C
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`recursiveMap can be used with return values to collect content # 1`] = `
+[
+  <li>
+    Should be included 1/3
+  </li>,
+  <li>
+    Should be included 2/3
+  </li>,
+  <li>
+    Should be included 3/3
+  </li>,
+]
+`;
+
+exports[`recursiveMap can be used with return values to collect content # 2`] = `
+[
+  <p>
+    1/3
+  </p>,
+  <p>
+    2/3
+  </p>,
+  <p>
+    3/3
+  </p>,
+]
+`;

--- a/src/core/utils/__tests__/findAllElementsOfType.test.tsx
+++ b/src/core/utils/__tests__/findAllElementsOfType.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { findAllElementsOfType } from '../findAllElementsOfType';
+
+describe('findAllElementsOfType', () => {
+  const flattenedListItems = (
+    <ul>
+      <li>Should be included 1/2</li>
+      <li>Should be included 2/2</li>
+    </ul>
+  );
+
+  const nestedListItems = (
+    <div>
+      <ul>
+        <li>Should be included 1/3</li>
+      </ul>
+      <ol>
+        <li>Should be included 2/3</li>
+        <li>Should be included 3/3</li>
+      </ol>
+    </div>
+  );
+
+  it.each([
+    [flattenedListItems, ['li'], 2], // 2 x <li>
+    [nestedListItems, ['li'], 3], // 3 x <li>
+    [nestedListItems, ['ul', 'ol', 'li'], 5], // <ul>, <ol>, 3 x <li>
+    [
+      <div>
+        <div>{nestedListItems}</div>
+      </div>,
+      ['li'],
+      3, // 3 x <li>
+    ],
+    [
+      <div>
+        <div>{nestedListItems}</div>
+        <div>
+          <span>
+            <img alt="should be included 1/2" src="#" />
+          </span>
+        </div>
+        <img alt="should be included 2/2" src="#" />
+        <div>
+          <p>Not included</p>
+        </div>
+      </div>,
+      ['img'],
+      2, // 2 x <img>
+    ],
+  ])(
+    'finds the elements of searched types #',
+    (component, types, foundCount) => {
+      const { children } = component.props;
+      const result = findAllElementsOfType(children, types);
+      expect(result).toHaveLength(foundCount);
+      expect(result).toMatchSnapshot();
+    },
+  );
+});

--- a/src/core/utils/__tests__/getChildrenByType.test.tsx
+++ b/src/core/utils/__tests__/getChildrenByType.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { getChildrenByType } from '../getChildrenByType';
+
+describe('getChildrenByType', () => {
+  it.each([
+    [
+      ['img', 'p'],
+      <>
+        <p>should contain 1/3</p>
+        <img alt="should contain 2/3" src="#" />
+        <span>should not contain</span>
+        <p>should contain 3/3</p>
+      </>,
+      3,
+    ],
+    [
+      ['ul'],
+      <>
+        <ol>
+          <li>Should not contain</li>
+        </ol>
+        <ul>
+          <li>Should contain 1/2</li>
+        </ul>
+        <p>Should not contain</p>
+        <hr />
+        <ul>
+          <li>Should contain 2/2</li>
+        </ul>
+      </>,
+      2,
+    ],
+  ])(
+    'filters childrens by defined list of types',
+    (types, component, filteredCount) => {
+      const { children } = component.props;
+      const result = getChildrenByType(children, types);
+      expect(result).toHaveLength(filteredCount);
+      expect(result).toMatchSnapshot();
+    },
+  );
+});

--- a/src/core/utils/__tests__/recursiveMap.test.tsx
+++ b/src/core/utils/__tests__/recursiveMap.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { recursiveMap } from '../recursiveMap';
+import { typeOfComponent } from '../getChildrenByType';
+
+describe('recursiveMap', () => {
+  const flattenedListItems = (
+    <ul>
+      <li>Should be included 1/2</li>
+      <li>Should be included 2/2</li>
+    </ul>
+  );
+
+  const nestedListItems = (
+    <div>
+      <ul>
+        <li>Should be included 1/3</li>
+      </ul>
+      <ol>
+        <li>Should be included 2/3</li>
+        <li>Should be included 3/3</li>
+      </ol>
+    </div>
+  );
+
+  it.each([
+    [flattenedListItems, jest.fn(), 2], // 2 x <li>
+    [nestedListItems, jest.fn(), 1 + 1 + 3], // <ul>, <ol> and 3 x <li>
+    [
+      <div>
+        <div>{nestedListItems}</div>
+      </div>,
+      jest.fn(),
+      1 + 1 + 1 + 1 + 3, // <div>, sub <div>, <ul>, <ol> and 3 x <li>
+    ],
+  ])('recursively calls the defined function', (component, fn, callCount) => {
+    const { children } = component.props;
+    recursiveMap(children, fn);
+    expect(fn).toHaveBeenCalledTimes(callCount);
+  });
+
+  it('can be used with void functions e.g. to count elements', () => {
+    const { children } = nestedListItems.props;
+    const elementCounts = {
+      li: 3,
+      ul: 1,
+      ol: 1,
+    };
+    const elementCounter: Record<keyof typeof elementCounts, number> = {
+      li: 0,
+      ul: 0,
+      ol: 0,
+    };
+    const fn = (child: React.ReactElement) => {
+      switch (typeOfComponent(child)) {
+        case 'li':
+          elementCounter.li += 1;
+          break;
+        case 'ul':
+          elementCounter.ul += 1;
+          break;
+        case 'ol':
+          elementCounter.ol += 1;
+          break;
+        default:
+          break;
+      }
+      return child;
+    };
+    recursiveMap(children, fn);
+    expect(elementCounter).toStrictEqual(elementCounts);
+  });
+
+  it.each([
+    [nestedListItems, 'li', 3],
+    [
+      <div>
+        <p>1/3</p>
+        <div>
+          <p>2/3</p>
+        </div>
+        <div>
+          <div>
+            <p>3/3</p>
+          </div>
+        </div>
+      </div>,
+      'p',
+      3,
+    ],
+  ])(
+    'can be used with return values to collect content #',
+    (component, type, elementCount) => {
+      const { children } = component.props;
+      const result = [];
+      const fn = (child: React.ReactElement) => {
+        if (typeOfComponent(child) === type) result.push(child);
+        return child;
+      };
+      recursiveMap(children, fn);
+      expect(result).toHaveLength(elementCount);
+      expect(result).toMatchSnapshot();
+    },
+  );
+
+  it('can be used to modify each children of a React node', () => {
+    const {
+      props: { children },
+    } = (
+      <>
+        <div>A</div>
+        <div>
+          <div>B</div>
+        </div>
+        <div>
+          <div>
+            <div>C</div>
+          </div>
+        </div>
+      </>
+    );
+    const fn = (child: React.ReactElement) =>
+      React.cloneElement(child, { className: 'newTestClassInEveryElement' });
+    const result = recursiveMap(children, fn);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/core/utils/findAllElementsOfType.ts
+++ b/src/core/utils/findAllElementsOfType.ts
@@ -1,0 +1,18 @@
+import { getChildrenByType } from './getChildrenByType';
+import { recursiveMap } from './recursiveMap';
+
+/**
+ * Find all elements of defined types recursively from a ReactNode.
+ * @returns a list of elements of specified types that could be found from inside the ReactNode.
+ */
+export const findAllElementsOfType = (
+  children: React.ReactNode,
+  types: string[],
+) => {
+  const elementsOfType = [];
+  recursiveMap(children, (child) => {
+    elementsOfType.push(getChildrenByType(child, types));
+    return child;
+  });
+  return elementsOfType.flat();
+};

--- a/src/core/utils/getChildrenByType.ts
+++ b/src/core/utils/getChildrenByType.ts
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Gets the string type of the component or core html (JSX) element.
+ * React Fragments will return type 'react.fragment'.
+ * Priority will be given to the prop '__TYPE'.
+ *
+ * @param {ReactNode} component - The component to type check
+ * @returns {string} - The string representation of the type
+ */
+export const typeOfComponent = (component) =>
+  // eslint-disable-next-line no-underscore-dangle
+  component?.props?.__TYPE ||
+  component?.type
+    ?.toString()
+    .replace('Symbol(react.fragment)', 'react.fragment') ||
+  undefined;
+
+/**
+ * Gets all children by specified type.
+ * This function will check the prop '__TYPE' first
+ * and then the 'type' string to match core html elements.
+ * To find a React Fragment, search for type 'react.fragment'.
+ *
+ * @param {ReactNode} children - JSX children
+ * @param {string[]} types - Types of children to match
+ * @returns {ReactNode[]} - Array of matching children
+ * @example
+ * // Finds all occurrences of ToDo (custom component), div, and React Fragment
+ * getChildrenByType(children, ['ToDo', 'div', 'react.fragment']);
+ */
+export const getChildrenByType = (children: React.ReactNode, types: string[]) =>
+  React.Children.toArray(children).filter(
+    (child) => types.indexOf(typeOfComponent(child)) !== -1,
+  );

--- a/src/core/utils/getChildrenByType.ts
+++ b/src/core/utils/getChildrenByType.ts
@@ -4,11 +4,8 @@ import React from 'react';
  * Gets the string type of the component or core html (JSX) element.
  * React Fragments will return type 'react.fragment'.
  * Priority will be given to the prop '__TYPE'.
- *
- * @param {ReactNode} component - The component to type check
- * @returns {string} - The string representation of the type
  */
-export const typeOfComponent = (component) =>
+export const typeOfComponent = (component: React.ReactElement): string =>
   // eslint-disable-next-line no-underscore-dangle
   component?.props?.__TYPE ||
   component?.type
@@ -22,14 +19,16 @@ export const typeOfComponent = (component) =>
  * and then the 'type' string to match core html elements.
  * To find a React Fragment, search for type 'react.fragment'.
  *
- * @param {ReactNode} children - JSX children
- * @param {string[]} types - Types of children to match
- * @returns {ReactNode[]} - Array of matching children
  * @example
  * // Finds all occurrences of ToDo (custom component), div, and React Fragment
  * getChildrenByType(children, ['ToDo', 'div', 'react.fragment']);
  */
-export const getChildrenByType = (children: React.ReactNode, types: string[]) =>
+export const getChildrenByType = (
+  children: React.ReactNode,
+  types: string[],
+): React.ReactNode[] =>
   React.Children.toArray(children).filter(
-    (child) => types.indexOf(typeOfComponent(child)) !== -1,
+    (child) =>
+      React.isValidElement(child) &&
+      types.indexOf(typeOfComponent(child)) !== -1,
   );

--- a/src/core/utils/recursiveMap.ts
+++ b/src/core/utils/recursiveMap.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+
+/**
+ * Recursively loops through the children of a ReactNode
+ * and runs the given function from arguments to the every child.
+ *
+ * If the child is a ReactElement and it has children,
+ * the children will be recursively called with the given function.
+ *
+ * If the child is not a valid ReactElement,
+ * which would mean that it is for example a string content of an HTML-element,
+ * it is directly returned.
+ *
+ * See the unit tests for some examples.
+ */
+export const recursiveMap = (
+  children: React.ReactNode,
+  fn: (children: React.ReactNode) => React.ReactNode,
+) =>
+  React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      // Strings inside HTML elements, etc.
+      return child;
+    }
+
+    if (child.props.children) {
+      // Make a recursive call to find the last node
+      return fn(
+        React.cloneElement(child as React.ReactElement, {
+          children: recursiveMap(child.props.children, fn),
+        }),
+      );
+    }
+    // Should never(?) come here
+    return fn(child);
+  })?.flat();


### PR DESCRIPTION
HCRC-112.

If there is an image included in the Link children, the external link icon should not be rendered by default  for the external links. It can be forced with `showExternalIcon` prop.

<img width="388" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/750c6b37-eb3e-4748-8c7c-0d882c34c0e3">

Also fixed the styles of the secondary link.

In a secondary link, an anchor element had span for  text and another for the link icon. Both the subelements were displayed as flex, which made them to fill the whole row and rendering the icon in another row compared to the text.
