### PR TITLE
LIIKUNTA-610 | fix: order languages in Navigation to order Finnish, Swedish & English

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha252",
+  "version": "1.0.0-alpha253",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -124,3 +124,4 @@ export { SearchPageContent } from './archiveSearchPageContent/ArchiveSearchPageC
 export { BackgroundImage, BackgroundImageProps } from './image/BackgroundImage';
 export { Image, ImageProps } from './image/Image';
 export { useResolveImageUrl } from './hooks/useResolveImageUrl';
+export * from './language';

--- a/src/core/language/__tests__/languageSorter.test.tsx
+++ b/src/core/language/__tests__/languageSorter.test.tsx
@@ -1,0 +1,31 @@
+import { languageSorter, NonEmptyLanguage } from '..';
+import { LanguageCodeEnum } from '../../../common/headlessService/__generated__';
+
+type TestLanguage = 'fi' | 'sv' | 'en';
+
+const TEST_LANGUAGES = {
+  fi: { id: 'fi', code: LanguageCodeEnum.Fi, name: 'Suomi' },
+  sv: { id: 'sv', code: LanguageCodeEnum.Sv, name: 'Svenska' },
+  en: { id: 'en', code: LanguageCodeEnum.En, name: 'English' },
+} as const satisfies Record<TestLanguage, NonEmptyLanguage>;
+
+const getNonEmptyLanguage = (language: TestLanguage): NonEmptyLanguage =>
+  TEST_LANGUAGES[language];
+
+describe('languageSorter function', () => {
+  it.each<Array<Array<TestLanguage>>>([
+    [['fi', 'en', 'sv']],
+    [['fi', 'sv', 'en']],
+    [['en', 'fi', 'sv']],
+    [['en', 'sv', 'fi']],
+    [['sv', 'fi', 'en']],
+    [['sv', 'en', 'fi']],
+  ])(
+    'sorts languages %p to Finnish, Swedish & English',
+    async (testLanguages: TestLanguage[]) => {
+      expect(
+        testLanguages.map(getNonEmptyLanguage).sort(languageSorter),
+      ).toEqual([TEST_LANGUAGES.fi, TEST_LANGUAGES.sv, TEST_LANGUAGES.en]);
+    },
+  );
+});

--- a/src/core/language/constants.ts
+++ b/src/core/language/constants.ts
@@ -1,0 +1,8 @@
+import { LanguageCodeEnum } from '../../common/headlessService/types';
+
+/** Default order for sorting languages. */
+export const LANGUAGE_CODE_ORDINAL_NUMBER = {
+  [LanguageCodeEnum.Fi]: 1, // 1st
+  [LanguageCodeEnum.Sv]: 2, // 2nd
+  [LanguageCodeEnum.En]: 3, // 3rd
+} as const satisfies Record<LanguageCodeEnum, number>;

--- a/src/core/language/findLanguage.ts
+++ b/src/core/language/findLanguage.ts
@@ -1,0 +1,19 @@
+import { Language } from '../../common/headlessService/types';
+
+/**
+ * Find language from language list by language code.
+ * @param {Language[]} languages - List of languages
+ * @param {string} languageCode - Language code
+ * @returns {Language | undefined} Language from given language list with the given
+ *                                 language code or undefined if not found
+ */
+function findLanguage(
+  languages: Language[],
+  languageCode: string,
+): Language | undefined {
+  return languages.find(
+    (language) => language.code?.toLowerCase() === languageCode.toLowerCase(),
+  );
+}
+
+export default findLanguage;

--- a/src/core/language/index.ts
+++ b/src/core/language/index.ts
@@ -1,0 +1,6 @@
+export * from './constants';
+export { default as findLanguage } from './findLanguage';
+export { default as languageSorter } from './languageSorter';
+export { default as toPrimaryLanguageOption } from './toPrimaryLanguageOption';
+export * from './typeGuards';
+export * from './types';

--- a/src/core/language/languageSorter.ts
+++ b/src/core/language/languageSorter.ts
@@ -1,0 +1,11 @@
+import { LANGUAGE_CODE_ORDINAL_NUMBER } from './constants';
+import { NonEmptyLanguage } from './types';
+
+/** Sorting function for NonEmptyLanguage elements. */
+const languageSorter = (left: NonEmptyLanguage, right: NonEmptyLanguage) =>
+  Math.sign(
+    LANGUAGE_CODE_ORDINAL_NUMBER[left.code] -
+      LANGUAGE_CODE_ORDINAL_NUMBER[right.code],
+  );
+
+export default languageSorter;

--- a/src/core/language/toPrimaryLanguageOption.ts
+++ b/src/core/language/toPrimaryLanguageOption.ts
@@ -1,0 +1,14 @@
+import { LanguageOption } from 'hds-react';
+
+import { NonEmptyLanguage } from './types';
+
+/** Map a NonEmptyLanguage to a primary LanguageOption. */
+const toPrimaryLanguageOption = (
+  language: NonEmptyLanguage,
+): LanguageOption => ({
+  label: language.name,
+  value: language.code.toLowerCase(),
+  isPrimary: true,
+});
+
+export default toPrimaryLanguageOption;

--- a/src/core/language/typeGuards.ts
+++ b/src/core/language/typeGuards.ts
@@ -1,0 +1,6 @@
+import { NonEmptyLanguage } from './types';
+import { Language } from '../../common/headlessService/types';
+
+export const isNonEmptyLanguage = (
+  language?: Language | null,
+): language is NonEmptyLanguage => Boolean(language?.name && language?.code);

--- a/src/core/language/types.ts
+++ b/src/core/language/types.ts
@@ -1,0 +1,4 @@
+import { Language } from '../../common/headlessService/types';
+
+export type NonEmptyLanguage = Language &
+  Required<Pick<Language, 'code' | 'name'>>;

--- a/src/core/navigation/Navigation.tsx
+++ b/src/core/navigation/Navigation.tsx
@@ -11,6 +11,12 @@ import {
 } from '../../common/constants';
 import { getTranslationWithFallback } from '../translation/getTranslationWithFallback';
 import { FallbackTranslationKey } from '../translation/types';
+import {
+  findLanguage,
+  isNonEmptyLanguage,
+  languageSorter,
+  toPrimaryLanguageOption,
+} from '../language';
 
 type MenuItem = Omit<
   NonNullable<NonNullable<Menu>['menuItems']>['nodes'][0],
@@ -31,22 +37,6 @@ export type NavigationProps = {
   ) => string;
   getIsItemActive?: (menuItem: MenuItem) => boolean;
 };
-
-/**
- * Find language from language list by language code.
- * @param {Language[]} languages - List of languages
- * @param {string} languageCode - Language code
- * @returns {Language | undefined} Language from given language list with the given
- *                                 language code or undefined if not found
- */
-function findLanguage(
-  languages: Language[],
-  languageCode: string,
-): Language | undefined {
-  return languages.find(
-    (language) => language.code?.toLowerCase() === languageCode.toLowerCase(),
-  );
-}
 
 interface MenuItemChildren {
   [menuItemId: string]: MenuItem[];
@@ -133,20 +123,10 @@ export function Navigation({
     );
   }
 
-  const languageOptions = languages.reduce(
-    (result: LanguageOption[], language) =>
-      language?.name && language?.code
-        ? [
-            ...result,
-            {
-              label: language.name,
-              value: language.code?.toLowerCase(),
-              isPrimary: true,
-            },
-          ]
-        : result,
-    [],
-  );
+  const languageOptions: LanguageOption[] = languages
+    .filter(isNonEmptyLanguage)
+    .sort(languageSorter)
+    .map(toPrimaryLanguageOption);
 
   const onDidChangeLanguage = (newLanguageCode: string) => {
     const newLanguage = findLanguage(languages, newLanguageCode);


### PR DESCRIPTION
## Description

### fix: order languages in Navigation to order Finnish, Swedish & English

also:
 - bump version to v1.0.0-alpha253

refs LIIKUNTA-610

## Issues

### Closes

[LIIKUNTA-610](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-610)

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

The **language order** in the Navigation component in **storybook** is now "**Suomi Svenska English**",
i.e. Finnish, Swedish and English as intended:

![image](https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/77663720/d4041e86-ef55-4da9-8129-d02ac12083d4)

## Additional notes

Published as [canary build](https://www.npmjs.com/package/react-helsinki-headless-cms/v/1.0.0-alpha252-canary-8ff25d9) for testing with events-helsinki-monorepo in https://github.com/City-of-Helsinki/events-helsinki-monorepo/pull/627


[LIIKUNTA-610]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ