### PR TITLE
feat: breadcrumbs included in the page and the post queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha255",
+  "version": "1.0.0-alpha256",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/apollo/apollo.stories.tsx
+++ b/src/apollo/apollo.stories.tsx
@@ -11,7 +11,7 @@ import { Navigation } from './navigation/Navigation';
 import { Notification } from './notification/Notification';
 import { Page } from './page/Page';
 import { PageContentLayout } from '../core/pageContent/PageContentLayout';
-import { LanguageCodeEnum } from '../core';
+import { LanguageCodeEnum, PageType, getBreadcrumbsFromPage } from '../core';
 import { useCmsEndpointConfig } from '../storybook-common/useCmsEndpointConfig';
 import {
   CmsEndpoint,
@@ -94,10 +94,7 @@ const ApolloBasicExample = {
     notification: <Notification />,
     content: (
       <PageContent
-        breadcrumbs={[
-          { title: 'Root', link: '/' },
-          { title: 'Nested', link: '/nested' },
-        ]}
+        breadcrumbs={(page: PageType) => getBreadcrumbsFromPage(page)}
       />
     ),
     footer: <>TODO: Implement footer</>,

--- a/src/common/eventsService/__generated__.ts
+++ b/src/common/eventsService/__generated__.ts
@@ -103,7 +103,7 @@ export type EventDetails = {
   name: LocalizedObject;
   offers: Array<Offer>;
   provider?: Maybe<LocalizedObject>;
-  providerContactInfo?: Maybe<Scalars['String']['output']>;
+  providerContactInfo?: Maybe<LocalizedObject>;
   publisher?: Maybe<Scalars['ID']['output']>;
   remainingAttendeeCapacity?: Maybe<Scalars['Int']['output']>;
   shortDescription?: Maybe<LocalizedObject>;

--- a/src/common/headlessService/__generated__.ts
+++ b/src/common/headlessService/__generated__.ts
@@ -69,6 +69,15 @@ export enum AvatarRatingEnum {
   X = 'X',
 }
 
+/** Breadcumb field */
+export type Breadcrumb = {
+  __typename?: 'Breadcrumb';
+  /** The title of the page */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The link of the page. */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
 /** Kortin kenttä */
 export type Card = {
   __typename?: 'Card';
@@ -4741,6 +4750,8 @@ export type Page = ContentNode &
     authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
     authorId?: Maybe<Scalars['ID']['output']>;
+    /** Breadcrumb fields */
+    breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
     /** Connection between the HierarchicalContentNode type and the ContentNode type */
     children?: Maybe<HierarchicalContentNodeToContentNodeChildrenConnection>;
     /** The content of the post. */
@@ -5126,6 +5137,8 @@ export type Post = ContentNode &
     authorDatabaseId?: Maybe<Scalars['Int']['output']>;
     /** The globally unique identifier of the author of the node */
     authorId?: Maybe<Scalars['ID']['output']>;
+    /** Breadcrumb fields */
+    breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
     /** Connection between the Post type and the category type */
     categories?: Maybe<PostToCategoryConnection>;
     /** The content of the post. */
@@ -8999,8 +9012,6 @@ export type SiteSettings = {
   logo?: Maybe<Scalars['String']['output']>;
   /** Identifying name */
   siteName?: Maybe<Scalars['String']['output']>;
-  /** Default wave motif */
-  waveMotif?: Maybe<Scalars['String']['output']>;
 };
 
 /** Vaiheen kenttä */
@@ -11182,6 +11193,11 @@ export type PostFragment = {
       photographerName?: string | null;
     };
   } | null;
+  breadcrumbs?: Array<{
+    __typename?: 'Breadcrumb';
+    title?: string | null;
+    uri?: string | null;
+  } | null> | null;
   sidebar?: Array<
     | {
         __typename: 'LayoutArticles';
@@ -11572,6 +11588,11 @@ export type ArticleQuery = {
         photographerName?: string | null;
       };
     } | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
     sidebar?: Array<
       | {
           __typename: 'LayoutArticles';
@@ -11986,6 +12007,11 @@ export type PostsQuery = {
             photographerName?: string | null;
           };
         } | null;
+        breadcrumbs?: Array<{
+          __typename?: 'Breadcrumb';
+          title?: string | null;
+          uri?: string | null;
+        } | null> | null;
         sidebar?: Array<
           | {
               __typename: 'LayoutArticles';
@@ -12543,6 +12569,11 @@ export type MenuItemFragment = {
                         photographerName?: string | null;
                       };
                     } | null;
+                    breadcrumbs?: Array<{
+                      __typename?: 'Breadcrumb';
+                      title?: string | null;
+                      uri?: string | null;
+                    } | null> | null;
                     sidebar?: Array<
                       | {
                           __typename: 'LayoutArticles';
@@ -12904,6 +12935,11 @@ export type MenuItemFragment = {
                       photographerName?: string | null;
                     };
                   } | null;
+                  breadcrumbs?: Array<{
+                    __typename?: 'Breadcrumb';
+                    title?: string | null;
+                    uri?: string | null;
+                  } | null> | null;
                   sidebar?: Array<
                     | {
                         __typename: 'LayoutArticles';
@@ -13308,6 +13344,11 @@ export type MenuItemFragment = {
                 photographerName?: string | null;
               };
             } | null;
+            breadcrumbs?: Array<{
+              __typename?: 'Breadcrumb';
+              title?: string | null;
+              uri?: string | null;
+            } | null> | null;
             sidebar?: Array<
               | {
                   __typename: 'LayoutArticles';
@@ -13669,6 +13710,11 @@ export type MenuItemFragment = {
               photographerName?: string | null;
             };
           } | null;
+          breadcrumbs?: Array<{
+            __typename?: 'Breadcrumb';
+            title?: string | null;
+            uri?: string | null;
+          } | null> | null;
           sidebar?: Array<
             | {
                 __typename: 'LayoutArticles';
@@ -14107,6 +14153,11 @@ export type MenuPageFieldsFragment = {
         photographerName?: string | null;
       };
     } | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
     sidebar?: Array<
       | {
           __typename: 'LayoutArticles';
@@ -14459,6 +14510,11 @@ export type MenuPageFieldsFragment = {
       photographerName?: string | null;
     };
   } | null;
+  breadcrumbs?: Array<{
+    __typename?: 'Breadcrumb';
+    title?: string | null;
+    uri?: string | null;
+  } | null> | null;
   sidebar?: Array<
     | {
         __typename: 'LayoutArticles';
@@ -14902,6 +14958,11 @@ export type MenuQuery = {
                               photographerName?: string | null;
                             };
                           } | null;
+                          breadcrumbs?: Array<{
+                            __typename?: 'Breadcrumb';
+                            title?: string | null;
+                            uri?: string | null;
+                          } | null> | null;
                           sidebar?: Array<
                             | {
                                 __typename: 'LayoutArticles';
@@ -15263,6 +15324,11 @@ export type MenuQuery = {
                             photographerName?: string | null;
                           };
                         } | null;
+                        breadcrumbs?: Array<{
+                          __typename?: 'Breadcrumb';
+                          title?: string | null;
+                          uri?: string | null;
+                        } | null> | null;
                         sidebar?: Array<
                           | {
                               __typename: 'LayoutArticles';
@@ -15667,6 +15733,11 @@ export type MenuQuery = {
                       photographerName?: string | null;
                     };
                   } | null;
+                  breadcrumbs?: Array<{
+                    __typename?: 'Breadcrumb';
+                    title?: string | null;
+                    uri?: string | null;
+                  } | null> | null;
                   sidebar?: Array<
                     | {
                         __typename: 'LayoutArticles';
@@ -16028,6 +16099,11 @@ export type MenuQuery = {
                     photographerName?: string | null;
                   };
                 } | null;
+                breadcrumbs?: Array<{
+                  __typename?: 'Breadcrumb';
+                  title?: string | null;
+                  uri?: string | null;
+                } | null> | null;
                 sidebar?: Array<
                   | {
                       __typename: 'LayoutArticles';
@@ -16711,6 +16787,11 @@ export type PageFragment = {
       photographerName?: string | null;
     };
   } | null;
+  breadcrumbs?: Array<{
+    __typename?: 'Breadcrumb';
+    title?: string | null;
+    uri?: string | null;
+  } | null> | null;
   sidebar?: Array<
     | {
         __typename: 'LayoutArticles';
@@ -17107,6 +17188,11 @@ export type PageQuery = {
         photographerName?: string | null;
       };
     } | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
     sidebar?: Array<
       | {
           __typename: 'LayoutArticles';
@@ -17505,6 +17591,11 @@ export type PageByTemplateQuery = {
         photographerName?: string | null;
       };
     } | null;
+    breadcrumbs?: Array<{
+      __typename?: 'Breadcrumb';
+      title?: string | null;
+      uri?: string | null;
+    } | null> | null;
     sidebar?: Array<
       | {
           __typename: 'LayoutArticles';
@@ -17933,6 +18024,11 @@ export type PageChildrenSearchQuery = {
                     photographerName?: string | null;
                   };
                 } | null;
+                breadcrumbs?: Array<{
+                  __typename?: 'Breadcrumb';
+                  title?: string | null;
+                  uri?: string | null;
+                } | null> | null;
                 sidebar?: Array<
                   | {
                       __typename: 'LayoutArticles';
@@ -18294,6 +18390,11 @@ export type PageChildrenSearchQuery = {
                   photographerName?: string | null;
                 };
               } | null;
+              breadcrumbs?: Array<{
+                __typename?: 'Breadcrumb';
+                title?: string | null;
+                uri?: string | null;
+              } | null> | null;
               sidebar?: Array<
                 | {
                     __typename: 'LayoutArticles';
@@ -18721,6 +18822,11 @@ export type PagesQuery = {
             photographerName?: string | null;
           };
         } | null;
+        breadcrumbs?: Array<{
+          __typename?: 'Breadcrumb';
+          title?: string | null;
+          uri?: string | null;
+        } | null> | null;
         sidebar?: Array<
           | {
               __typename: 'LayoutArticles';
@@ -19445,6 +19551,10 @@ export const PostFragmentDoc = gql`
         photographerName
       }
     }
+    breadcrumbs {
+      title
+      uri
+    }
     sidebar {
       ... on LayoutLinkList {
         ...LayoutLinkList
@@ -19587,6 +19697,10 @@ export const PageFragmentDoc = gql`
         uri
         photographerName
       }
+    }
+    breadcrumbs {
+      title
+      uri
     }
     sidebar {
       ... on LayoutLinkList {

--- a/src/common/headlessService/graphql/article.graphql
+++ b/src/common/headlessService/graphql/article.graphql
@@ -48,6 +48,10 @@ fragment Post on Post {
       photographerName
     }
   }
+  breadcrumbs {
+    title
+    uri
+  }
   sidebar {
     ... on LayoutLinkList {
       ...LayoutLinkList

--- a/src/common/headlessService/graphql/page.graphql
+++ b/src/common/headlessService/graphql/page.graphql
@@ -47,6 +47,10 @@ fragment Page on Page {
       photographerName
     }
   }
+  breadcrumbs {
+    title
+    uri
+  }
   sidebar {
     ... on LayoutLinkList {
       ...LayoutLinkList

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -79,6 +79,7 @@ export {
   getLocationCardProps,
   getCollectionCards,
   getCollectionUIType,
+  getBreadcrumbsFromPage,
 } from './pageContent/utils';
 
 // naming overlaps with type exported above

--- a/src/core/pageContent/PageContent.tsx
+++ b/src/core/pageContent/PageContent.tsx
@@ -44,7 +44,9 @@ import { MAIN_CONTENT_ID } from '../../common/constants';
 
 export type PageContentProps = {
   page?: PageType | ArticleType;
-  breadcrumbs?: Breadcrumb[];
+  breadcrumbs?:
+    | Breadcrumb[]
+    | ((page?: PageType | ArticleType) => Breadcrumb[]);
   content?:
     | React.ReactNode
     | ((page: PageType | ArticleType) => React.ReactNode);
@@ -257,7 +259,15 @@ export function PageContent(props: PageContentProps) {
         {...pageContentLayoutProps}
         {...getHeroProps()}
         breadcrumbs={
-          breadcrumbs && <PageContentBreadcrumbs breadcrumbs={breadcrumbs} />
+          breadcrumbs && (
+            <PageContentBreadcrumbs
+              breadcrumbs={
+                typeof breadcrumbs === 'function'
+                  ? breadcrumbs(page)
+                  : breadcrumbs
+              }
+            />
+          )
         }
         heroContainer={heroContainer}
         id={page?.id ?? 'page'}

--- a/src/core/pageContent/utils.ts
+++ b/src/core/pageContent/utils.ts
@@ -1,3 +1,5 @@
+import { uniqBy } from 'lodash-es';
+
 import { EventType } from '../../common/eventsService/types';
 import {
   ArticleType,
@@ -32,6 +34,7 @@ import {
   GeneralCollectionType,
   LocationsSelectionCollectionType,
 } from '../collection/types';
+import { Breadcrumb } from './types';
 
 export function getCollections(
   pageModules: PageModule[],
@@ -170,3 +173,20 @@ export function getCollectionUIType(
   // eslint-disable-next-line no-underscore-dangle
   return collection.__typename.includes('Carousel') ? 'carousel' : 'grid';
 }
+
+/**
+ * Create Breadcrumb objects from the pages' and articles' breadcrumbs.
+ * The duplicated root (and other duplicated links) are removed.
+ * @param page a page or an article
+ * @returns an unique list of breadcrumb objects
+ * */
+export const getBreadcrumbsFromPage = (
+  page: PageType | ArticleType,
+): Breadcrumb[] =>
+  uniqBy(
+    page.breadcrumbs.map((breadcrumb) => ({
+      title: breadcrumb.title,
+      link: breadcrumb.uri,
+    })),
+    'link',
+  );


### PR DESCRIPTION
LIIKUNTA-611.
Add breadcrumbs field to the page and the post query.
Add an utility that can be used to convert the uri-property to a link-property
and to clear the duplicated paths from the breadcrumbs.

<img width="1281" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/a7526f5b-5f5b-4fd2-9308-27bf4c3288bf">
<img width="1316" alt="image" src="https://github.com/City-of-Helsinki/react-helsinki-headless-cms/assets/389204/c5e8d734-df90-4ad6-8e5e-5a33ecb3ddf6">

