### PR TITLE
PT-1720 | fix(navigation): override header max width using style instead of theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha268",
+  "version": "1.0.0-alpha269",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/navigation/Navigation.tsx
+++ b/src/core/navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { groupBy } from 'lodash-es';
-import { Header, HeaderTheme, LanguageOption, Logo } from 'hds-react';
+import { Header, LanguageOption, Logo } from 'hds-react';
 
 import { Config } from '../configProvider/configContext';
 import { Language, Menu } from '../../common/headlessService/types';
@@ -153,7 +153,7 @@ export function Navigation({
     A,
   };
 
-  const theme: HeaderTheme = {
+  const overrideHeaderMaxWidth = {
     '--header-max-width': 'var(--breakpoint-xl)', // Would be 1440px if not overridden
   };
 
@@ -163,7 +163,12 @@ export function Navigation({
       defaultLanguage={currentLanguage?.code?.toLowerCase()}
       languages={languageOptions}
       className={className}
-      theme={theme}
+      style={
+        /* HDS v3.4–v3.6 has broken theme support with next.js SSR & hydration.
+         * FIXME: Replace with `theme={overrideHeaderMaxWidth}` when HDS theme support is fixed.
+         */
+        overrideHeaderMaxWidth as React.CSSProperties
+      }
     >
       <Header.SkipLink
         skipTo={`#${mainContentId ?? MAIN_CONTENT_ID}`}


### PR DESCRIPTION
## Description

NOTE:
- Published as canary build [1.0.0-alpha269-canary-30a4d44](https://www.npmjs.com/package/react-helsinki-headless-cms/v/1.0.0-alpha269-canary-30a4d44) for testing

### fix(navigation): override header max width using style instead of theme

HDS v3.4–v3.6 has broken theme support with next.js SSR & hydration.
Using `style` instead of `theme` in HDS Header as a workaround.

refs PT-1720 (the broken behavior was uncovered as a part of this)

## Issues

### Closes

### Related

[PT-1720](https://helsinkisolutionoffice.atlassian.net/browse/PT-1720)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[PT-1720]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ