### PR TITLE
fix(navigation): override header max width using style instead of theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha272",
+  "version": "1.0.0-alpha273",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/navigation/Navigation.tsx
+++ b/src/core/navigation/Navigation.tsx
@@ -163,7 +163,12 @@ export function Navigation({
       defaultLanguage={currentLanguage?.code?.toLowerCase()}
       languages={languageOptions}
       className={className}
-      theme={overrideHeaderMaxWidth}
+      style={
+        /* HDS v3.4–v3.7 has broken theme support with next.js SSR & hydration.
+         * FIXME: Replace with `theme={overrideHeaderMaxWidth}` when HDS theme support is fixed.
+         */
+        overrideHeaderMaxWidth as React.CSSProperties
+      }
     >
       <Header.SkipLink
         skipTo={`#${mainContentId ?? MAIN_CONTENT_ID}`}


### PR DESCRIPTION
## Description

### fix(navigation): override header max width using style instead of theme

HDS v3.4–v3.7 has broken theme support with next.js SSR & hydration.
Using `style` instead of `theme` in HDS Header as a workaround.

bump version to v1.0.0-alpha273

refs PT-1720 (the broken behavior was uncovered as a part of this)

## Issues

### Closes

### Related

[PT-1720](https://helsinkisolutionoffice.atlassian.net/browse/PT-1720)

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[PT-1720]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ