### PR TITLE
fix: add meta tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha273",
+  "version": "1.0.0-alpha274",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha274",
+  "version": "1.0.0-alpha275",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/core/pageContent/meta/PageMeta.tsx
+++ b/src/core/pageContent/meta/PageMeta.tsx
@@ -53,9 +53,9 @@ export function PageMeta({ page, headComponent: Head }: PageMetaProps) {
         </>
       )}
       {openGraphType && <meta property="og:type" content={openGraphType} />}
-      {xTitle && <meta name="twitter:title" content={twitterTitle} />}
+      {xTitle && <meta name="twitter:title" content={xTitle} />}
       {xDescription && (
-        <meta name="twitter:description" content={twitterDescription} />
+        <meta name="twitter:description" content={xDescription} />
       )}
       <link rel="icon" href={meta?.favIconUrl} sizes="any" />
       <link rel="icon" href={meta?.favIconSvgUrl} type="image/svg+xml" />

--- a/src/core/pageContent/meta/PageMeta.tsx
+++ b/src/core/pageContent/meta/PageMeta.tsx
@@ -32,6 +32,8 @@ export function PageMeta({ page, headComponent: Head }: PageMetaProps) {
     openGraphDescription,
   } = seoForCurrentLanguage ?? {};
   const image = seoForCurrentLanguage?.socialImage?.mediaItemUrl;
+  const xTitle = twitterTitle ?? title ?? undefined;
+  const xDescription = twitterDescription ?? description ?? undefined;
 
   const { meta } = useConfig();
 
@@ -43,10 +45,16 @@ export function PageMeta({ page, headComponent: Head }: PageMetaProps) {
       {openGraphDescription && (
         <meta property="og:description" content={openGraphDescription} />
       )}
-      {image && <meta property="og:image" content={image} />}
+      <meta name="twitter:card" content="summary_large_image" />
+      {image && (
+        <>
+          <meta property="og:image" content={image} />
+          <meta property="twitter:image" content={image} />
+        </>
+      )}
       {openGraphType && <meta property="og:type" content={openGraphType} />}
-      {twitterTitle && <meta name="twitter:title" content={twitterTitle} />}
-      {twitterDescription && (
+      {xTitle && <meta name="twitter:title" content={twitterTitle} />}
+      {xDescription && (
         <meta name="twitter:description" content={twitterDescription} />
       )}
       <link rel="icon" href={meta?.favIconUrl} sizes="any" />


### PR DESCRIPTION
## Description
When pasting the link to Miro, link is not displayed as a card. Og tags are not enough, but twitter tags should be provided to enable this feature.
## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
