### PR TITLE
Use new CMS urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-CMS_GRAPHQL_ENDPOINT=https://liikunta.hkih.stage.geniem.io/graphql
+CMS_GRAPHQL_ENDPOINT=https://liikunta.app-staging.hkih.hion.dev/graphql
 EVENTS_GRAPHQL_ENDPOINT=https://events-graphql-proxy.test.hel.ninja/proxy/graphql
 LINKED_EVENTS_ENDPOINT=https://api.hel.fi/linkedevents/v1/event/
 VENUES_GRAPHQL_ENDPOINT=https://venue-graphql-proxy.test.hel.ninja/proxy/graphql

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-helsinki-headless-cms",
-  "version": "1.0.0-alpha291",
+  "version": "1.0.0-alpha292",
   "description": "React components for displaying Headless CMS content according to guidelines set by HDS",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const CMS_GRAPHQL_ENDPOINT =
-  process.env.CMS_GRAPHQL_ENDPOINT ?? 'https://hkih.stage.geniem.io/graphql';
+  process.env.CMS_GRAPHQL_ENDPOINT ??
+  'https://app-staging.hkih.hion.dev/graphql';
 export const EVENTS_PROXY_ENDPOINT =
   process.env.EVENTS_GRAPHQL_ENDPOINT ??
   'https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql';

--- a/src/core/navigation/__mocks__/navigationMenu.mock.ts
+++ b/src/core/navigation/__mocks__/navigationMenu.mock.ts
@@ -31,7 +31,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/lapset-ja-perheet/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/lapset-ja-perheet/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/lapset-ja-perheet/',
         label: 'Lapset ja perheet',
       },
       {
@@ -41,7 +41,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/aikuiset/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/aikuiset/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/aikuiset/',
         label: 'Aikuiset',
       },
       {
@@ -61,7 +61,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/',
         label: 'Liikuntatilojen varaaminen',
       },
       {
@@ -71,7 +71,7 @@ const navigationMenu = {
         path: '/fi/pages/liikuntapalvelut/maksut-ja-hinnasto/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/liikuntapalvelut/maksut-ja-hinnasto/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/liikuntapalvelut/maksut-ja-hinnasto/',
         label: 'Maksut ja hinnasto',
       },
       {
@@ -81,7 +81,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/',
         label: 'Ohjeet vuorojen hakemiseen',
       },
       {
@@ -91,7 +91,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/%ef%bf%bc/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/%ef%bf%bc/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/ohjeet-vuorojen-hakemiseen/%ef%bf%bc/',
         label: 'Ohjeet vaalitilaisuuden tilavaraukseen',
       },
       {
@@ -101,7 +101,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/vuorojenjakokriteerit/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/vuorojenjakokriteerit/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/vuorojenjakokriteerit/',
         label: 'Vuorojenjakokriteerit',
       },
       {
@@ -111,7 +111,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/',
         label: 'Liikuntapalvelun hallinnoimat koulutilat',
       },
       {
@@ -121,7 +121,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/helsingin-kaupungin-koulujen-liikuntasalien-vapaa-ajan-kaytto/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/helsingin-kaupungin-koulujen-liikuntasalien-vapaa-ajan-kaytto/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/helsingin-kaupungin-koulujen-liikuntasalien-vapaa-ajan-kaytto/',
         label: 'Helsingin kaupungin koulujen liikuntasalien vapaa-ajan käyttö',
       },
       {
@@ -131,7 +131,7 @@ const navigationMenu = {
         path: '/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/koulujen-liikuntasalien-itsenainen-kaytto/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/koulujen-liikuntasalien-itsenainen-kaytto/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/kohderyhmat/kumppanit/tilojen-varaaminen/liikuntapalvelun-hallinnoimat-koulutilat/koulujen-liikuntasalien-itsenainen-kaytto/',
         label: 'Koulujen liikuntasalien itsenäinen käyttö',
       },
     ],

--- a/src/core/navigation/__mocks__/navigationUniversalBarMenu.mock.ts
+++ b/src/core/navigation/__mocks__/navigationUniversalBarMenu.mock.ts
@@ -11,7 +11,7 @@ const navigationUniversalBarMenu = {
         path: '/fi/pages/tietoa-palvelusta/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/tietoa-palvelusta/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/tietoa-palvelusta/',
         label: 'Tietoa palvelusta',
       },
       {
@@ -21,7 +21,7 @@ const navigationUniversalBarMenu = {
         path: '/fi/pages/liikuntapalvelut/maaraykset-ja-ohjeet/',
         target: null,
         title: null,
-        url: 'https://liikunta.hkih.stage.geniem.io/fi/pages/liikuntapalvelut/maaraykset-ja-ohjeet/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/fi/pages/liikuntapalvelut/maaraykset-ja-ohjeet/',
         label: 'Määräykset ja ohjeet',
       },
     ],

--- a/src/core/page/Page.stories.tsx
+++ b/src/core/page/Page.stories.tsx
@@ -39,7 +39,8 @@ export default {
 
 const domain = window.location.origin ?? 'http://localhost:6006';
 const cmsDomain = new URL(
-  process.env.CMS_GRAPHQL_ENDPOINT ?? 'https://hkih.stage.geniem.io/graphql',
+  process.env.CMS_GRAPHQL_ENDPOINT ??
+    'https://app-staging.hkih.hion.dev/graphql',
 ).origin;
 const Template: StoryFn<typeof Page> = (args) => (
   <HelmetProvider>

--- a/src/core/pageContent/__mocks__/page.mock.ts
+++ b/src/core/pageContent/__mocks__/page.mock.ts
@@ -35,7 +35,7 @@ export const sidebarCardsList: LayoutCards = {
       link: {
         target: '',
         title: 'Read more',
-        url: 'https://liikunta.hkih.stage.geniem.io/en/regulations-and-instructions/hygiene-in-pool-premises/',
+        url: 'https://liikunta.app-staging.hkih.hion.dev/en/regulations-and-instructions/hygiene-in-pool-premises/',
       },
     },
   ],
@@ -70,7 +70,7 @@ export const sidebarArticleList: LayoutArticle = {
         node: {
           altText: 'image description',
           mediaItemUrl:
-            'https://kultus.hkih.stage.geniem.io/uploads/2022/01/ae0d30ec-w_c3391_l_web.jpeg',
+            'https://kultus.app-staging.hkih.hion.dev/uploads/2022/01/ae0d30ec-w_c3391_l_web.jpeg',
         },
       },
       __typename: 'Post',

--- a/src/core/pageContent/__mocks__/pageWithDiverseContent.mock.ts
+++ b/src/core/pageContent/__mocks__/pageWithDiverseContent.mock.ts
@@ -16,7 +16,7 @@ const pageWithDiverseContent: PageQuery['page'] = {
     <dd>Description</dd>
   </dl>
   <figure>
-    <img src="https://kultus.hkih.stage.geniem.io/uploads/2022/01/ae0d30ec-w_c3391_l_web.jpeg" alt="Alt text" />
+    <img src="https://kultus.app-staging.hkih.hion.dev/uploads/2022/01/ae0d30ec-w_c3391_l_web.jpeg" alt="Alt text" />
     <figcaption>Fig.1 - Figure caption</figcaption>
   </figure>
   <hr />

--- a/src/mocks/responses/cms/languages/hobbies-languages.json
+++ b/src/mocks/responses/cms/languages/hobbies-languages.json
@@ -2,7 +2,7 @@
   "languages": [
     {
       "code": "FI",
-      "homeUrl": "https://harrastus.hkih.stage.geniem.io/fi/",
+      "homeUrl": "https://harrastus.app-staging.hkih.hion.dev/fi/",
       "id": "TGFuZ3VhZ2U6Zmk=",
       "locale": "fi",
       "name": "Suomi",
@@ -11,7 +11,7 @@
     },
     {
       "code": "EN",
-      "homeUrl": "https://harrastus.hkih.stage.geniem.io/en/",
+      "homeUrl": "https://harrastus.app-staging.hkih.hion.dev/en/",
       "id": "TGFuZ3VhZ2U6ZW4=",
       "locale": "en_US",
       "name": "English",
@@ -20,7 +20,7 @@
     },
     {
       "code": "SV",
-      "homeUrl": "https://harrastus.hkih.stage.geniem.io/sv/",
+      "homeUrl": "https://harrastus.app-staging.hkih.hion.dev/sv/",
       "id": "TGFuZ3VhZ2U6c3Y=",
       "locale": "sv_SE",
       "name": "Svenska",

--- a/src/mocks/responses/cms/page/kukkuu-page-demosivu.json
+++ b/src/mocks/responses/cms/page/kukkuu-page-demosivu.json
@@ -1,11 +1,11 @@
 {
   "page": {
     "id": "cG9zdDo4MA==",
-    "content": "\n<p>Demosivu</p>\n\n\n\n<p><a href=\"https://google.com\">Ulkoinen linkki</a></p>\n\n\n\n<p><a href=\"https://google.fi\" target=\"_blank\" rel=\"noreferrer noopener\">Ulkoinen linkki uusi ikkuna</a></p>\n\n\n\n<p><a href=\"https://kukkuu.hkih.stage.geniem.io/sivu-3/\" data-type=\"page\" data-id=\"24\">Sisäinen linkki</a></p>\n\n\n\n<p class=\"has-text-align-left\">Youtube: </p>\n\n\n\n<figure class=\"wp-block-embed aligncenter is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<iframe loading=\"lazy\" title=\"Bohemian Rhapsody | Muppet Music Video | The Muppets\" width=\"500\" height=\"281\" src=\"https://www.youtube.com/embed/tgbNymZ7vqY?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n</div><figcaption class=\"wp-element-caption\">Youtube caption</figcaption></figure>\n\n\n\n<p>Vimeo:</p>\n\n\n\n<figure class=\"wp-block-embed is-type-video is-provider-vimeo wp-block-embed-vimeo wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<iframe loading=\"lazy\" title=\"The New Vimeo Player (You Know, For Videos)\" src=\"https://player.vimeo.com/video/76979871?h=8272103f6e&amp;dnt=1&amp;app_id=122963\" width=\"500\" height=\"281\" frameborder=\"0\" allow=\"autoplay; fullscreen; picture-in-picture\" allowfullscreen></iframe>\n</div><figcaption class=\"wp-element-caption\">Vimeo caption</figcaption></figure>\n",
+    "content": "\n<p>Demosivu</p>\n\n\n\n<p><a href=\"https://google.com\">Ulkoinen linkki</a></p>\n\n\n\n<p><a href=\"https://google.fi\" target=\"_blank\" rel=\"noreferrer noopener\">Ulkoinen linkki uusi ikkuna</a></p>\n\n\n\n<p><a href=\"https://kukkuu.app-staging.hkih.hion.dev/sivu-3/\" data-type=\"page\" data-id=\"24\">Sisäinen linkki</a></p>\n\n\n\n<p class=\"has-text-align-left\">Youtube: </p>\n\n\n\n<figure class=\"wp-block-embed aligncenter is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<iframe loading=\"lazy\" title=\"Bohemian Rhapsody | Muppet Music Video | The Muppets\" width=\"500\" height=\"281\" src=\"https://www.youtube.com/embed/tgbNymZ7vqY?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen></iframe>\n</div><figcaption class=\"wp-element-caption\">Youtube caption</figcaption></figure>\n\n\n\n<p>Vimeo:</p>\n\n\n\n<figure class=\"wp-block-embed is-type-video is-provider-vimeo wp-block-embed-vimeo wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<iframe loading=\"lazy\" title=\"The New Vimeo Player (You Know, For Videos)\" src=\"https://player.vimeo.com/video/76979871?h=8272103f6e&amp;dnt=1&amp;app_id=122963\" width=\"500\" height=\"281\" frameborder=\"0\" allow=\"autoplay; fullscreen; picture-in-picture\" allowfullscreen></iframe>\n</div><figcaption class=\"wp-element-caption\">Vimeo caption</figcaption></figure>\n",
     "slug": "demosivu",
     "title": "Demosivu",
     "uri": "/demosivu/",
-    "link": "https://kukkuu.hkih.stage.geniem.io/demosivu/",
+    "link": "https://kukkuu.app-staging.hkih.hion.dev/demosivu/",
     "lead": "",
     "seo": {
       "title": "Demosivu &#x2d; Kukkuu",
@@ -15,7 +15,7 @@
       "openGraphType": "website",
       "twitterTitle": "Demosivu",
       "twitterDescription": "Demosivu Ulkoinen linkki Ulkoinen linkki uusi ikkuna Sis&auml;inen linkki Youtube: Vimeo&#8230;",
-      "canonicalUrl": "https://kukkuu.hkih.stage.geniem.io/demosivu/",
+      "canonicalUrl": "https://kukkuu.app-staging.hkih.hion.dev/demosivu/",
       "socialImage": null,
       "__typename": "SEO"
     },

--- a/src/storybook-common/constants.ts
+++ b/src/storybook-common/constants.ts
@@ -1,9 +1,9 @@
 export enum CmsEndpoint {
-  kultus = 'https://kultus.hkih.stage.geniem.io/graphql',
-  kukkuu = 'https://kukkuu.hkih.stage.geniem.io/graphql',
-  events = 'https://tapahtumat.hkih.stage.geniem.io/graphql',
-  hobbies = 'https://harrastus.hkih.stage.geniem.io/graphql',
-  sports = 'https://liikunta.hkih.stage.geniem.io/graphql',
+  kultus = 'https://kultus.app-staging.hkih.hion.dev/graphql',
+  kukkuu = 'https://kukkuu.app-staging.hkih.hion.dev/graphql',
+  events = 'https://tapahtumat.app-staging.hkih.hion.dev/graphql',
+  hobbies = 'https://harrastus.app-staging.hkih.hion.dev/graphql',
+  sports = 'https://liikunta.app-staging.hkih.hion.dev/graphql',
 }
 
 export const cmsTestPage: Record<keyof typeof CmsEndpoint, string> = {


### PR DESCRIPTION
## Description

### feat: use new CMS urls everywhere, bump version to 1.0.0-alpha292

done:
 - replace ".hkih.stage.geniem.io" with ".app-staging.hkih.hion.dev"
 - replace "https://hkih.stage.geniem.io/" with
   "https://app-staging.hkih.hion.dev/"

refs KK-1196 (kukkuu new CMS urls)
refs LIIKUNTA-669 (events-helsinki-monorepo new CMS urls)
refs PT-1751 (palvelutarjotin new CMS urls)

## Issues

[KK-1196](https://helsinkisolutionoffice.atlassian.net/browse/KK-1196)
[LIIKUNTA-669](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-669)
[PT-1751](https://helsinkisolutionoffice.atlassian.net/issues/PT-1751)

### Closes

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes


[KK-1196]: https://helsinkisolutionoffice.atlassian.net/browse/KK-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIIKUNTA-669]: https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PT-1751]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ