### PR TITLE
fix: button style inside card HCRC-194

### DIFF
--- a/src/core/pageModules/CardsModule/SimpleCard.tsx
+++ b/src/core/pageModules/CardsModule/SimpleCard.tsx
@@ -102,7 +102,7 @@ export function SimpleCard({
               variant={ButtonVariant.Secondary}
               theme={ButtonPresetTheme.Black}
               onClick={handleClick}
-              iconStart={
+              iconEnd={
                 <IconAngleRight aria-hidden="true" size={IconSize.Small} />
               }
             >

--- a/src/core/pageModules/pageModules.module.scss
+++ b/src/core/pageModules/pageModules.module.scss
@@ -71,11 +71,6 @@
       flex-direction: column;
     }
   }
-
-  & svg {
-    height: 84px;
-    width: 84px;
-  }
 }
 
 .cardContent {
@@ -119,6 +114,11 @@
   align-items: center;
   margin-right: 0;
   margin-bottom: 16px;
+
+  & svg {
+    height: 84px;
+    width: 84px;
+  }
 
   &.horisontal {
     @include breakpoints.respond_above(s) {


### PR DESCRIPTION
Refs: HCRC-194

## Description

Fixes a problem with icon inside a button on Card components.

Style that was meant for the big icon in the Card was also affecting icon downstream inside the button. Now it's targeted more accurately.


### Closes

**[HCRC-194](https://helsinkisolutionoffice.atlassian.net/browse/HCRC-194):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

Bug:
<img width="993" height="917" alt="Screenshot 2026-05-13 at 15 58 42" src="https://github.com/user-attachments/assets/7516fcd1-3287-4df3-ae9b-d45a457bf437" />

Fix:
<img width="595" height="599" alt="Screenshot 2026-05-13 at 16 41 59" src="https://github.com/user-attachments/assets/c10af1f5-326a-470e-adbb-2136ec762cad" />



[HCRC-194]: https://helsinkisolutionoffice.atlassian.net/browse/HCRC-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ