### PR TITLE
feat!: promote React 19 / hds-react 6 migration to 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ It provides:
 pnpm add @city-of-helsinki/react-helsinki-headless-cms
 ```
 
+**Requires React 19 and hds-react 6** as peer dependencies (since v4.0.0). For React 18 / hds-react 4–5, use the v3.x line.
+
 ## Development
 
 **NOTE: The library is for general use and should not be developed for a single application environment only!** Check [the known clients](#the-known-clients-that-are-using-this-library)


### PR DESCRIPTION
The React 19 + hds-react 6 migration (already on `main`) merged as a non-breaking `feat:`, so release-please's release PR proposed **3.2.0**. Dropping React 18 and requiring hds-react 6 is breaking for consumers and should be a **major** release.

This PR:
- Documents the new peer requirement in the README Installation section.
- Carries a `feat!:` commit with a `BREAKING CHANGE:` footer and `Release-As: 4.0.0`, so release-please recomputes the pending release to **4.0.0**.

(Replaces #268, whose empty commit was dropped on merge.)

Refs: RATY-357