### PR TITLE
fix: update hds to 6.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/City-of-Helsinki/react-helsinki-headless-cms#readme",
   "peerDependencies": {
     "@apollo/client": "^3.14.0",
-    "hds-react": "^6.0.4",
+    "hds-react": "^6.0.5",
     "react": "^19",
     "react-dom": "^19"
   },
@@ -115,8 +115,8 @@
     "git-rev-sync": "^3.0.2",
     "globals": "^17.4.0",
     "graphql": "^16.12.0",
-    "hds-core": "^6.0.4",
-    "hds-react": "^6.0.4",
+    "hds-core": "^6.0.5",
+    "hds-react": "^6.0.5",
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "lint-staged": "^16.2.7",
@@ -151,7 +151,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "doctoc": "^2.3.0",
-    "hds-design-tokens": "^6.0.4",
+    "hds-design-tokens": "^6.0.5",
     "html-entities": "^2.6.0",
     "html-react-parser": "^5.2.5",
     "isomorphic-dompurify": "^2.36.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/City-of-Helsinki/react-helsinki-headless-cms#readme",
   "peerDependencies": {
     "@apollo/client": "^3.14.0",
-    "hds-react": "^6.0.2",
+    "hds-react": "^6.0.4",
     "react": "^19",
     "react-dom": "^19"
   },
@@ -115,8 +115,8 @@
     "git-rev-sync": "^3.0.2",
     "globals": "^17.4.0",
     "graphql": "^16.12.0",
-    "hds-core": "^6.0.2",
-    "hds-react": "6.0.2",
+    "hds-core": "^6.0.4",
+    "hds-react": "^6.0.4",
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "lint-staged": "^16.2.7",
@@ -151,7 +151,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "doctoc": "^2.3.0",
-    "hds-design-tokens": "^6.0.2",
+    "hds-design-tokens": "^6.0.4",
     "html-entities": "^2.6.0",
     "html-react-parser": "^5.2.5",
     "isomorphic-dompurify": "^2.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.3.0
         version: 2.4.1
       hds-design-tokens:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.4
+        version: 6.0.4
       html-entities:
         specifier: ^2.6.0
         version: 2.6.0
@@ -199,11 +199,11 @@ importers:
         specifier: ^16.12.0
         version: 16.14.0
       hds-core:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^6.0.4
+        version: 6.0.4
       hds-react:
-        specifier: 6.0.2
-        version: 6.0.2(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 6.0.4
+        version: 6.0.4(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -2007,12 +2007,6 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
 
@@ -3055,9 +3049,6 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -5222,16 +5213,16 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hds-core@6.0.2:
-    resolution: {integrity: sha512-WJoIjxGFUSnpFQOGzkpphdbC/2fa9eDXYK2+ODt1pJCCZARLrkl5vMt3+0dqq5oRZ7g/kZd9j7Xc7ZDqR5/aDA==}
+  hds-core@6.0.4:
+    resolution: {integrity: sha512-b60TOCFrIuOrMIH5ZTjRTZ6bZIj9F4vGgMrd/VzxUDlLFzYR9x8rsr3JtI3Jb0IZsbcjw96P0DWGK8pIboT4iQ==}
     engines: {node: ^24}
 
-  hds-design-tokens@6.0.2:
-    resolution: {integrity: sha512-/OxfpXo+lTU8OkaXGVYhZxpdzRcO8sUSMo5gfxqAvryvtvNv4RPx0xDrAEq7mhr3I6DFPJVRYvExQicoqHFgPQ==}
+  hds-design-tokens@6.0.4:
+    resolution: {integrity: sha512-3O7Q7mks9BdcC4XGjUBnU7AB2mjQmjhPhmvTM1KealExfiY2iUSuHKanL70IE/PtLPtiSrRiB6NwhSZJPWB6sg==}
     engines: {node: ^24}
 
-  hds-react@6.0.2:
-    resolution: {integrity: sha512-ALlUjw+rkJ6m3muH8r/9QsVvImQ8jAKuAK6W8gIQ55R09N9NoZf/imPelAvZBgi/w8mqhfyLsQfuexUWUJRaWw==}
+  hds-react@6.0.4:
+    resolution: {integrity: sha512-Q/ec7x4OG9nPKehiRFrGBoDyW2BqdkTChixwQ0CYlr3FPzaoBGtANY9GBsetby0AKfZOHGNV6K83S25kWsVhfQ==}
     engines: {node: ^24}
     peerDependencies:
       postcss: ^8.4.21
@@ -10618,13 +10609,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@neoconfetti/react@1.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -10957,7 +10941,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.2':
@@ -11504,11 +11488,6 @@ snapshots:
       - supports-color
 
   '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -14009,11 +13988,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hds-core@6.0.2: {}
+  hds-core@6.0.4: {}
 
-  hds-design-tokens@6.0.2: {}
+  hds-design-tokens@6.0.4: {}
 
-  hds-react@6.0.2(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  hds-react@6.0.4(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@apollo/client': 3.14.1(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@babel/runtime': 7.29.7
@@ -14028,8 +14007,8 @@ snapshots:
       crc-32: 1.2.0
       date-fns: 2.16.1
       graphql: 16.14.0
-      hds-core: 6.0.2
-      hds-design-tokens: 6.0.2
+      hds-core: 6.0.4
+      hds-design-tokens: 6.0.4
       jwt-decode: 3.1.2
       kashe: 1.0.4
       lodash: 4.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.3.0
         version: 2.4.1
       hds-design-tokens:
-        specifier: ^6.0.4
-        version: 6.0.4
+        specifier: ^6.0.5
+        version: 6.0.5
       html-entities:
         specifier: ^2.6.0
         version: 2.6.0
@@ -199,11 +199,11 @@ importers:
         specifier: ^16.12.0
         version: 16.14.0
       hds-core:
-        specifier: ^6.0.4
-        version: 6.0.4
+        specifier: ^6.0.5
+        version: 6.0.5
       hds-react:
-        specifier: ^6.0.4
-        version: 6.0.4(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^6.0.5
+        version: 6.0.5(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1109,6 +1109,12 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@csstools/selector-specificity@2.2.0':
+    resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
+    engines: {node: ^14 || ^16 || >=18}
+    peerDependencies:
+      postcss-selector-parser: ^6.0.10
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -1988,8 +1994,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@juggle/resize-observer@3.2.0':
-    resolution: {integrity: sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==}
+  '@juggle/resize-observer@3.4.0':
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -2374,52 +2380,41 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@popperjs/core@2.11.5':
-    resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@react-aria/interactions@3.28.0':
-    resolution: {integrity: sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==}
+  '@react-aria/visually-hidden@3.9.1':
+    resolution: {integrity: sha512-PWuth+NTmUiBJAIyrfk7dJ5BxOBupDt0iFGlBiYr5FElSYvwN9LAk1kgkzm6hT2qzq4FmYdQgBSPkGeaxOui6w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-aria/utils@3.34.0':
-    resolution: {integrity: sha512-ZM1ZXIqpwGTJjjL6o3JhlZkEaBpQdxuOCqLEvwEwooaj5GsYI3E9UfOl5vy3UW6bYiEEWl9pNBntrb9CR9kItQ==}
+  '@react-spring/animated@9.7.5':
+    resolution: {integrity: sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@react-aria/visually-hidden@3.8.16':
-    resolution: {integrity: sha512-3zThVIzEprez4A/GajOut6/JQ4WCu2ROHGZ1xH1+2GFjBJQaTfPBIjg6UIwaT7sgHRQIik8QidogLqXHbp81yA==}
+  '@react-spring/core@9.7.5':
+    resolution: {integrity: sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@react-spring/animated@9.3.2':
-    resolution: {integrity: sha512-pBvKydRHbTzuyaeHtxGIOvnskZxGo/S5/YK1rtYm88b9NQZuZa95Rgd3O0muFL+99nvBMBL8cvQGD0UJmsqQsg==}
+  '@react-spring/rafz@9.7.5':
+    resolution: {integrity: sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==}
+
+  '@react-spring/shared@9.7.5':
+    resolution: {integrity: sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==}
     peerDependencies:
-      react: ^16.8.0  || ^17.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@react-spring/core@9.3.2':
-    resolution: {integrity: sha512-kMRjkgdQ6LJ0lmb/wQlONpghaMT83UxglXHJC6m9kZS/GKVmN//TYMEK85xN1rC5Gg+BmjG61DtLCSkkLDTfNw==}
+  '@react-spring/types@9.7.5':
+    resolution: {integrity: sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==}
+
+  '@react-spring/web@9.7.5':
+    resolution: {integrity: sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==}
     peerDependencies:
-      react: ^16.8.0  || ^17.0.0
-
-  '@react-spring/rafz@9.3.2':
-    resolution: {integrity: sha512-YtqNnAYp5bl6NdnDOD5TcYS40VJmB+Civ4LPtcWuRPKDAOa/XAf3nep48r0wPTmkK936mpX8aIm7h+luW59u5A==}
-
-  '@react-spring/shared@9.3.2':
-    resolution: {integrity: sha512-ypGQQ8w7mWnrELLon4h6mBCBxdd8j1pgLzmHXLpTC/f4ya2wdP+0WIKBWXJymIf+5NiTsXgSJra5SnHP5FBY+A==}
-    peerDependencies:
-      react: ^16.8.0  || ^17.0.0
-
-  '@react-spring/types@9.3.2':
-    resolution: {integrity: sha512-u+IK9z9Re4hjNkBYKebZr7xVDYTai2RNBsI4UPL/k0B6lCNSwuqWIXfKZUDVlMOeZHtDqayJn4xz6HcSkTj3FQ==}
-
-  '@react-spring/web@9.3.0':
-    resolution: {integrity: sha512-OTAGKRdyz6fLRR1tABFyw9KMpytyATIndQrj0O6RG47GfjiInpf4+WZKxo763vpS7z1OlnkI81WLUm/sqOqAnA==}
-    peerDependencies:
-      react: ^16.8.0  || ^17.0.0
-      react-dom: ^16.8.0  || ^17.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   '@react-types/shared@3.34.0':
     resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
@@ -3068,8 +3063,8 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/cookie@0.4.1':
-    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4136,8 +4131,8 @@ packages:
       typescript:
         optional: true
 
-  crc-32@1.2.0:
-    resolution: {integrity: sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==}
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
 
@@ -4282,15 +4277,12 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
-  date-fns@2.16.1:
-    resolution: {integrity: sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==}
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
   date-fns@4.3.0:
     resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
-
-  debounce@1.2.1:
-    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
   debounce@2.2.0:
     resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
@@ -4791,10 +4783,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  exit-on-epipe@1.0.1:
-    resolution: {integrity: sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==}
-    engines: {node: '>=0.8'}
-
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
@@ -5163,6 +5151,10 @@ packages:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -5213,16 +5205,16 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hds-core@6.0.4:
-    resolution: {integrity: sha512-b60TOCFrIuOrMIH5ZTjRTZ6bZIj9F4vGgMrd/VzxUDlLFzYR9x8rsr3JtI3Jb0IZsbcjw96P0DWGK8pIboT4iQ==}
+  hds-core@6.0.5:
+    resolution: {integrity: sha512-OMI4Thr+aZKuNTx1oXi28bBQ14elqBaF/gzszaNQerlYLR8lHeI6x4nTijU9Jqj6DiVGyQ8Hky6e0pdpLmBRNg==}
     engines: {node: ^24}
 
-  hds-design-tokens@6.0.4:
-    resolution: {integrity: sha512-3O7Q7mks9BdcC4XGjUBnU7AB2mjQmjhPhmvTM1KealExfiY2iUSuHKanL70IE/PtLPtiSrRiB6NwhSZJPWB6sg==}
+  hds-design-tokens@6.0.5:
+    resolution: {integrity: sha512-J9jlvTRFVxyzy4khDXbWGLXqfzhPyJp4i8WrWwmozEf0cIA3gGkHli0AvYCjjKM3G2L/3rinKqPBk310UZfuPA==}
     engines: {node: ^24}
 
-  hds-react@6.0.4:
-    resolution: {integrity: sha512-Q/ec7x4OG9nPKehiRFrGBoDyW2BqdkTChixwQ0CYlr3FPzaoBGtANY9GBsetby0AKfZOHGNV6K83S25kWsVhfQ==}
+  hds-react@6.0.5:
+    resolution: {integrity: sha512-OFaaPTop9UElK6NN/o99b/N+7+ZqQIYcYFM1OKtSw/yHLwHidoIRDbOsQqnGjSEpiTgNWLZjxhcSlwzNMdqiQg==}
     engines: {node: ^24}
     peerDependencies:
       postcss: ^8.4.21
@@ -5946,8 +5938,8 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
-  kashe@1.0.4:
-    resolution: {integrity: sha512-d4N2iljhOrTUszc+fRdfaFRPeu0+hZNbSlXnuTdVcN+IWFMByTNmQzA3SKb1bWctNVXi5RmYQYQjOWqu1mDXpw==}
+  kashe@1.2.0:
+    resolution: {integrity: sha512-XqrR1dQrNV5mxEvB3tAxOBpI49T1A6Kqs2tn4V6Hunv0CtwZKTgr97yVHxj54Bad6HZR9gLlMC+R2TYNf9wXMA==}
     engines: {node: '>=8.5.0'}
 
   keyv@4.5.4:
@@ -6221,9 +6213,6 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
-
-  memoize-one@5.2.1:
-    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
@@ -6849,6 +6838,12 @@ packages:
     peerDependencies:
       postcss: ^8.0.0
 
+  postcss-nesting@10.2.0:
+    resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
+    engines: {node: ^12 || ^14 || >=16}
+    peerDependencies:
+      postcss: ^8.2
+
   postcss-normalize-charset@5.1.0:
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
     engines: {node: ^10 || ^12 || >=14.0}
@@ -6986,11 +6981,6 @@ packages:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  printj@1.1.2:
-    resolution: {integrity: sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -7074,8 +7064,8 @@ packages:
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-hook-form@7.76.1:
-    resolution: {integrity: sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==}
+  react-hook-form@7.81.0:
+    resolution: {integrity: sha512-ocbmr2p5KBMoAfj4WCUvped33lVi1Kd5DuDUvQDnB6VEAacOjPI/jMbtDdbhco4y9ct4xUuCmMY0b/C9L0QHjw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -7095,11 +7085,12 @@ packages:
   react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
 
-  react-popper@2.2.5:
-    resolution: {integrity: sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==}
+  react-popper@2.3.0:
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
 
   react-property@2.0.2:
     resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
@@ -7109,11 +7100,14 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  react-use-measure@2.0.1:
-    resolution: {integrity: sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==}
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
     peerDependencies:
       react: '>=16.13'
       react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -8448,6 +8442,29 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@apollo/client@3.14.1(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@wry/caches': 1.0.1
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.14.2
+      graphql-tag: 2.12.6(graphql@16.14.2)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.1
+      prop-types: 15.8.1
+      rehackt: 0.1.0(@types/react@19.2.17)(react@19.2.7)
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.8.1
+      zen-observable-ts: 1.2.5
+    optionalDependencies:
+      graphql-ws: 6.0.8(graphql@16.14.0)(ws@8.21.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@ardatan/relay-compiler@13.0.1(graphql@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -9463,6 +9480,10 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.1.2)':
+    dependencies:
+      postcss-selector-parser: 6.1.2
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -10163,15 +10184,19 @@ snapshots:
     dependencies:
       graphql: 16.14.0
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hookform/resolvers@2.9.11(react-hook-form@7.76.1(react@19.2.7))':
+  '@hookform/resolvers@2.9.11(react-hook-form@7.81.0(react@19.2.7))':
     dependencies:
-      react-hook-form: 7.76.1(react@19.2.7)
+      react-hook-form: 7.81.0(react@19.2.7)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -10578,7 +10603,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@juggle/resize-observer@3.2.0': {}
+  '@juggle/resize-observer@3.4.0': {}
 
   '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
@@ -10835,63 +10860,44 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@popperjs/core@2.11.5': {}
+  '@popperjs/core@2.11.8': {}
 
-  '@react-aria/interactions@3.28.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.7)
-      '@swc/helpers': 0.5.21
-      react: 19.2.7
-      react-aria: 3.48.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-
-  '@react-aria/utils@3.34.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@react-aria/visually-hidden@3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@swc/helpers': 0.5.21
       react: 19.2.7
       react-aria: 3.48.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
-      react-stately: 3.46.0(react@19.2.7)
 
-  '@react-aria/visually-hidden@3.8.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@react-spring/animated@9.7.5(react@19.2.7)':
     dependencies:
-      '@react-aria/interactions': 3.28.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/utils': 3.34.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-types/shared': 3.34.0(react@19.2.7)
-      '@swc/helpers': 0.5.21
-      react: 19.2.7
-    transitivePeerDependencies:
-      - react-dom
-
-  '@react-spring/animated@9.3.2(react@19.2.7)':
-    dependencies:
-      '@react-spring/shared': 9.3.2(react@19.2.7)
-      '@react-spring/types': 9.3.2
+      '@react-spring/shared': 9.7.5(react@19.2.7)
+      '@react-spring/types': 9.7.5
       react: 19.2.7
 
-  '@react-spring/core@9.3.2(react@19.2.7)':
+  '@react-spring/core@9.7.5(react@19.2.7)':
     dependencies:
-      '@react-spring/animated': 9.3.2(react@19.2.7)
-      '@react-spring/shared': 9.3.2(react@19.2.7)
-      '@react-spring/types': 9.3.2
+      '@react-spring/animated': 9.7.5(react@19.2.7)
+      '@react-spring/shared': 9.7.5(react@19.2.7)
+      '@react-spring/types': 9.7.5
       react: 19.2.7
 
-  '@react-spring/rafz@9.3.2': {}
+  '@react-spring/rafz@9.7.5': {}
 
-  '@react-spring/shared@9.3.2(react@19.2.7)':
+  '@react-spring/shared@9.7.5(react@19.2.7)':
     dependencies:
-      '@react-spring/rafz': 9.3.2
-      '@react-spring/types': 9.3.2
+      '@react-spring/rafz': 9.7.5
+      '@react-spring/types': 9.7.5
       react: 19.2.7
 
-  '@react-spring/types@9.3.2': {}
+  '@react-spring/types@9.7.5': {}
 
-  '@react-spring/web@9.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@react-spring/web@9.7.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@react-spring/animated': 9.3.2(react@19.2.7)
-      '@react-spring/core': 9.3.2(react@19.2.7)
-      '@react-spring/shared': 9.3.2(react@19.2.7)
-      '@react-spring/types': 9.3.2
+      '@react-spring/animated': 9.7.5(react@19.2.7)
+      '@react-spring/core': 9.7.5(react@19.2.7)
+      '@react-spring/shared': 9.7.5(react@19.2.7)
+      '@react-spring/types': 9.7.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -11520,7 +11526,7 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/cookie@0.4.1': {}
+  '@types/cookie@0.6.0': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -12655,10 +12661,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  crc-32@1.2.0:
-    dependencies:
-      exit-on-epipe: 1.0.1
-      printj: 1.1.2
+  crc-32@1.2.2: {}
 
   create-ecdh@4.0.4:
     dependencies:
@@ -12860,11 +12863,11 @@ snapshots:
 
   dataloader@2.2.3: {}
 
-  date-fns@2.16.1: {}
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
 
   date-fns@4.3.0: {}
-
-  debounce@1.2.1: {}
 
   debounce@2.2.0: {}
 
@@ -13529,8 +13532,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  exit-on-epipe@1.0.1: {}
-
   exit-x@0.2.2: {}
 
   exit@0.1.2: {}
@@ -13930,6 +13931,11 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
+  graphql-tag@2.12.6(graphql@16.14.2):
+    dependencies:
+      graphql: 16.14.2
+      tslib: 2.8.1
+
   graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0):
     dependencies:
       graphql: 16.14.0
@@ -13937,6 +13943,8 @@ snapshots:
       ws: 8.21.0
 
   graphql@16.14.0: {}
+
+  graphql@16.14.2: {}
 
   has-bigints@1.1.0: {}
 
@@ -13988,39 +13996,39 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hds-core@6.0.4: {}
+  hds-core@6.0.5: {}
 
-  hds-design-tokens@6.0.4: {}
+  hds-design-tokens@6.0.5: {}
 
-  hds-react@6.0.4(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  hds-react@6.0.5(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@apollo/client': 3.14.1(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@apollo/client': 3.14.1(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(graphql@16.14.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@babel/runtime': 7.29.7
-      '@hookform/resolvers': 2.9.11(react-hook-form@7.76.1(react@19.2.7))
-      '@juggle/resize-observer': 3.2.0
-      '@popperjs/core': 2.11.5
-      '@react-aria/visually-hidden': 3.8.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-spring/web': 9.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@types/cookie': 0.4.1
+      '@hookform/resolvers': 2.9.11(react-hook-form@7.81.0(react@19.2.7))
+      '@juggle/resize-observer': 3.4.0
+      '@popperjs/core': 2.11.8
+      '@react-aria/visually-hidden': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-spring/web': 9.7.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/cookie': 0.6.0
       await-to-js: 3.0.0
       cookie: 0.7.2
-      crc-32: 1.2.0
-      date-fns: 2.16.1
-      graphql: 16.14.0
-      hds-core: 6.0.4
-      hds-design-tokens: 6.0.4
+      crc-32: 1.2.2
+      date-fns: 2.30.0
+      graphql: 16.14.2
+      hds-core: 6.0.5
+      hds-design-tokens: 6.0.5
       jwt-decode: 3.1.2
-      kashe: 1.0.4
+      kashe: 1.2.0
       lodash: 4.18.1
-      memoize-one: 5.2.1
       oidc-client-ts: 2.5.0
       postcss: 8.5.15
+      postcss-nesting: 10.2.0(postcss@8.5.15)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-hook-form: 7.76.1(react@19.2.7)
+      react-hook-form: 7.81.0(react@19.2.7)
       react-merge-refs: 1.1.0
-      react-popper: 2.2.5(@popperjs/core@2.11.5)(react@19.2.7)
-      react-use-measure: 2.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-use-measure: 2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       uuid: 14.0.1
       yup: 1.7.1
     transitivePeerDependencies:
@@ -15029,10 +15037,11 @@ snapshots:
 
   jwt-decode@3.1.2: {}
 
-  kashe@1.0.4:
+  kashe@1.2.0:
     dependencies:
       function-double: 1.0.4
       reselect: 4.1.8
+      tslib: 2.8.1
 
   keyv@4.5.4:
     dependencies:
@@ -15309,8 +15318,6 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
-
-  memoize-one@5.2.1: {}
 
   meow@13.2.0: {}
 
@@ -15971,6 +15978,12 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       string-hash: 1.1.3
 
+  postcss-nesting@10.2.0(postcss@8.5.15):
+    dependencies:
+      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.2
+
   postcss-normalize-charset@5.1.0(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
@@ -16101,8 +16114,6 @@ snapshots:
       react-is-18: react-is@18.3.1
       react-is-19: react-is@19.2.7
 
-  printj@1.1.2: {}
-
   process-nextick-args@2.0.1: {}
 
   process-on-spawn@1.1.0:
@@ -16218,7 +16229,7 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-hook-form@7.76.1(react@19.2.7):
+  react-hook-form@7.81.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -16232,10 +16243,11 @@ snapshots:
 
   react-merge-refs@1.1.0: {}
 
-  react-popper@2.2.5(@popperjs/core@2.11.5)(react@19.2.7):
+  react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@popperjs/core': 2.11.5
+      '@popperjs/core': 2.11.8
       react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       react-fast-compare: 3.2.2
       warning: 4.0.3
 
@@ -16251,10 +16263,10 @@ snapshots:
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
 
-  react-use-measure@2.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-use-measure@2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      debounce: 1.2.1
       react: 19.2.7
+    optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
         specifier: ^6.0.4
         version: 6.0.4
       hds-react:
-        specifier: 6.0.4
+        specifier: ^6.0.4
         version: 6.0.4(@types/react@19.2.17)(graphql-ws@6.0.8(graphql@16.14.0)(ws@8.21.0))(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       husky:
         specifier: ^9.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
 # Block installation of dependencies released less than 1 week ago (supply-chain hardening)
 minimumReleaseAge: 10080
 
+# Exempt HDS packages from the release-age gate. We often need a fresh release before
+# the 1-week window elapses.
+minimumReleaseAgeExclude:
+  - hds-*
+
 # Dependency overrides (pnpm equivalent of Yarn's "resolutions" in package.json).
 # - hds-react>cookie: fixes cookie <0.7.0 advisory pulled in transitively by hds-react.
 #   See https://github.com/City-of-Helsinki/react-helsinki-headless-cms/security/dependabot/28

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,13 @@ overrides:
   'lodash@^4.17': '^4.18.1'
   'uuid@8.3.2': '^11.1.1'
 
+# Accept peer-dependency mismatches that are known-safe and have no upstream fix yet.
+# - eslint-plugin-jsx-a11y>eslint: the plugin's peer range caps at eslint 9, but 6.10.2 (its
+#   latest release) runs cleanly under eslint 10. Remove once jsx-a11y ships eslint 10 support.
+peerDependencyRules:
+  allowedVersions:
+    'eslint-plugin-jsx-a11y>eslint': '10'
+
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true


### PR DESCRIPTION
## Description
- Update HDS to newest 6.0.5
- Fixes a warning at pnpm install





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated HDS React, Core, and Design Tokens packages to version 6.0.5.
  * Added a supply-chain hardening gate exemption for HDS packages.
  * Allowed a known ESLint peer-version mismatch for the current linting setup, including an explicit exception for `eslint-plugin-jsx-a11y>eslint` version 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->